### PR TITLE
chore: update package name in lockfile to follow-builders-scripts

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "follow-builders-fetcher",
+  "name": "follow-builders-scripts",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "follow-builders-fetcher",
+      "name": "follow-builders-scripts",
       "version": "1.0.0",
       "dependencies": {
         "dotenv": "^16.4.0",


### PR DESCRIPTION
Updates package name in `scripts/package-lock.json` from `follow-builders-fetcher` to `follow-builders-scripts` after running `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)