### PR TITLE
feat: add Chinese AI researchers to x_accounts sources

### DIFF
--- a/config/default-sources.json
+++ b/config/default-sources.json
@@ -72,6 +72,12 @@
     { "name": "Dan Shipper", "handle": "danshipper" },
     { "name": "Aditya Agarwal", "handle": "adityaag" },
     { "name": "Sam Altman", "handle": "sama" },
-    { "name": "Claude", "handle": "claudeai" }
+    { "name": "Claude", "handle": "claudeai" },
+    { "name": "Fei-Fei Li", "handle": "drfeifei" },
+    { "name": "Yangqing Jia", "handle": "jiayq" },
+    { "name": "Kaiming He", "handle": "kaiming0415" },
+    { "name": "Andrew Ng", "handle": "AndrewYNg" },
+    { "name": "Yi Tay", "handle": "yi_tay" },
+    { "name": "Saining Xie", "handle": "sainingxie" }
   ]
 }


### PR DESCRIPTION
Add 6 prominent Chinese/Chinese-American AI researchers who are active on X/Twitter and produce high-quality original content:

- Fei-Fei Li (@drfeifei) - Stanford / WorldLabs, ImageNet creator
- Yangqing Jia (@jiayq) - Lepton AI founder, Caffe author
- Kaiming He (@kaiming0415) - MIT, ResNet / MAE author
- Andrew Ng (@AndrewYNg) - DeepLearning.AI, AI education leader
- Yi Tay (@yi_tay) - Reka AI co-founder, ex-Google Brain
- Saining Xie (@sainingxie) - NYU / Meta, ConvNeXt author

These additions expand coverage to include leading voices from the Chinese AI research community across vision, NLP, and foundation models.