### PR TITLE
Fix: Use specific episode URL instead of channel URL

### DIFF
--- a/scripts/generate-feed.js
+++ b/scripts/generate-feed.js
@@ -254,7 +254,7 @@ async function fetchPodcastContent(podcasts, apiKey, state, errors) {
       name: selected.podcast.name,
       title: selected.title,
       guid: selected.guid,
-      url: selected.podcast.url,
+      url: selected.link,
       publishedAt: selected.publishedAt,
       transcript: result.transcript
     }];


### PR DESCRIPTION
## Bug

The podcast feed was using the channel URL from config (e.g., `youtube.com/@NoPriorsPodcast`) instead of the specific episode URL from RSS. This caused all "Listen" links to point to the channel page rather than the actual episode.

## Example

Before: `https://www.youtube.com/@NoPriorsPodcast` (channel page)
After: `https://youtube.com/watch?v=Iu4gEnZFQz8` (specific episode)

## Fix

Changed line 257 in `scripts/generate-feed.js`:



The `selected.link` field already contains the episode URL from RSS parsing (line 168), so we just needed to use it instead of the channel URL.

## Testing

The RSS parser extracts episode URLs correctly — this was a one-line fix to use the right field.