### PR TITLE
[codex] Add Codex compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ WhatsApp, etc.) with:
 
 ## Quick Start
 
-1. Install the skill in your agent (OpenClaw or Claude Code)
+1. Install the skill in your agent (OpenClaw, Codex, or Claude Code)
 2. Say "set up follow builders" or invoke `/follow-builders`
 3. The agent walks you through setup conversationally — no config files to edit
 
@@ -91,18 +91,21 @@ clawhub install follow-builders
 
 # Or manually
 git clone https://github.com/zarazhangrui/follow-builders.git ~/skills/follow-builders
-cd ~/skills/follow-builders/scripts && npm install
 ```
 
 ### Claude Code
 ```bash
 git clone https://github.com/zarazhangrui/follow-builders.git ~/.claude/skills/follow-builders
-cd ~/.claude/skills/follow-builders/scripts && npm install
+```
+
+### Codex
+```bash
+git clone https://github.com/zarazhangrui/follow-builders.git ~/.codex/skills/follow-builders
 ```
 
 ## Requirements
 
-- An AI agent (OpenClaw, Claude Code, or similar)
+- An AI agent (OpenClaw, Codex, Claude Code, or similar)
 - Internet connection (to fetch the central feed)
 
 That's it. No API keys needed. All content (blog articles + YouTube transcripts + X/Twitter posts)
@@ -128,4 +131,3 @@ See [examples/sample-digest.md](examples/sample-digest.md) for what the output l
 ## License
 
 MIT
-

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 
 ## 快速开始
 
-1. 在你的 AI agent 中安装此 skill（OpenClaw 或 Claude Code）
+1. 在你的 AI agent 中安装此 skill（OpenClaw、Codex 或 Claude Code）
 2. 输入 "set up follow builders" 或执行 `/follow-builders`
 3. Agent 会以对话方式引导你完成设置——不需要手动编辑任何配置文件
 
@@ -84,18 +84,21 @@ clawhub install follow-builders
 
 # 或手动安装
 git clone https://github.com/zarazhangrui/follow-builders.git ~/skills/follow-builders
-cd ~/skills/follow-builders/scripts && npm install
 ```
 
 ### Claude Code
 ```bash
 git clone https://github.com/zarazhangrui/follow-builders.git ~/.claude/skills/follow-builders
-cd ~/.claude/skills/follow-builders/scripts && npm install
+```
+
+### Codex
+```bash
+git clone https://github.com/zarazhangrui/follow-builders.git ~/.codex/skills/follow-builders
 ```
 
 ## 系统要求
 
-- 一个 AI agent（OpenClaw、Claude Code 或类似工具）
+- 一个 AI agent（OpenClaw、Codex、Claude Code 或类似工具）
 - 网络连接（用于获取中心化 feed）
 
 仅此而已。不需要任何 API key。所有内容（博客文章 + YouTube 字幕 + X/Twitter 帖子）由中心化服务每日抓取更新。

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,12 +26,17 @@ which openclaw 2>/dev/null && echo "PLATFORM=openclaw" || echo "PLATFORM=other"
   Delivery is automatic via OpenClaw's channel system. No need to ask about delivery method.
   Cron uses `openclaw cron add`.
 
-- **Other** (Claude Code, Cursor, etc.): Non-persistent agent. Terminal closes = agent stops.
+- **Other** (Codex, Claude Code, Cursor, etc.): Non-persistent agent. Terminal closes = agent stops.
   For automatic delivery, users MUST set up Telegram or Email. Without it, digests
   are on-demand only (user types `/ai` to get one).
   Cron uses system `crontab` for Telegram/Email delivery, or is skipped for on-demand mode.
 
 Save the detected platform in config.json as `"platform": "openclaw"` or `"platform": "other"`.
+When running in Codex, treat the platform as `"other"` and use this skill directory
+fallback for script commands:
+```bash
+SKILL_DIR="${SKILL_DIR:-$HOME/.codex/skills/follow-builders}"
+```
 
 ## First Run — Onboarding
 
@@ -69,7 +74,7 @@ For weekly, also ask which day.
 user's Telegram/Discord/WhatsApp/etc. Set `delivery.method` to `"stdout"` in config
 and move on.
 
-**If non-persistent agent (Claude Code, Cursor, etc.):**
+**If non-persistent agent (Codex, Claude Code, Cursor, etc.):**
 
 Tell the user:
 
@@ -318,7 +323,8 @@ This script handles ALL data fetching deterministically — feeds, prompts, conf
 You do NOT fetch anything yourself.
 
 ```bash
-cd ${CLAUDE_SKILL_DIR}/scripts && node prepare-digest.js 2>/dev/null
+SKILL_DIR="${SKILL_DIR:-$HOME/.codex/skills/follow-builders}"
+cd "$SKILL_DIR/scripts" && node prepare-digest.js 2>/dev/null
 ```
 
 The script outputs a single JSON blob with everything you need:
@@ -400,7 +406,8 @@ Read `config.delivery.method` from the JSON:
 **If "telegram" or "email":**
 ```bash
 echo '<your digest text>' > /tmp/fb-digest.txt
-cd ${CLAUDE_SKILL_DIR}/scripts && node deliver.js --file /tmp/fb-digest.txt 2>/dev/null
+SKILL_DIR="${SKILL_DIR:-$HOME/.codex/skills/follow-builders}"
+cd "$SKILL_DIR/scripts" && node deliver.js --file /tmp/fb-digest.txt 2>/dev/null
 ```
 If delivery fails, show the digest in the terminal as fallback.
 
@@ -439,7 +446,8 @@ customization persists and won't be overwritten by central updates.
 
 ```bash
 mkdir -p ~/.follow-builders/prompts
-cp ${CLAUDE_SKILL_DIR}/prompts/<filename>.md ~/.follow-builders/prompts/<filename>.md
+SKILL_DIR="${SKILL_DIR:-$HOME/.codex/skills/follow-builders}"
+cp "$SKILL_DIR/prompts/<filename>.md" ~/.follow-builders/prompts/<filename>.md
 ```
 
 Then edit `~/.follow-builders/prompts/<filename>.md` with the user's requested changes.

--- a/scripts/deliver.js
+++ b/scripts/deliver.js
@@ -24,13 +24,95 @@ import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { config as loadEnv } from 'dotenv';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 // -- Constants ---------------------------------------------------------------
 
 const USER_DIR = join(homedir(), '.follow-builders');
 const CONFIG_PATH = join(USER_DIR, 'config.json');
 const ENV_PATH = join(USER_DIR, '.env');
+const execFileAsync = promisify(execFile);
+
+// -- Environment loading -----------------------------------------------------
+
+async function loadEnvFile(path) {
+  if (!existsSync(path)) return;
+
+  const body = await readFile(path, 'utf-8');
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const match = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    let value = rawValue.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+// -- HTTP helpers ------------------------------------------------------------
+
+function responseFromBody(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body ? JSON.parse(body) : {};
+    },
+    async text() {
+      return body;
+    }
+  };
+}
+
+async function postJSON(url, payload, headers = {}) {
+  const args = [
+    '-sS',
+    '--max-time',
+    '30',
+    '-X',
+    'POST',
+    url,
+    '-H',
+    'Content-Type: application/json'
+  ];
+
+  for (const [key, value] of Object.entries(headers)) {
+    args.push('-H', `${key}: ${value}`);
+  }
+
+  args.push('--data-binary', JSON.stringify(payload), '-w', '\n%{http_code}');
+
+  try {
+    const { stdout } = await execFileAsync('curl', args, {
+      maxBuffer: 10 * 1024 * 1024
+    });
+    const splitAt = stdout.lastIndexOf('\n');
+    const body = splitAt === -1 ? '' : stdout.slice(0, splitAt);
+    const status = Number(splitAt === -1 ? stdout : stdout.slice(splitAt + 1));
+    return responseFromBody(status, body);
+  } catch {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(30000)
+    });
+    return responseFromBody(res.status, await res.text());
+  }
+}
 
 // -- Read input --------------------------------------------------------------
 
@@ -82,17 +164,13 @@ async function sendTelegram(text, botToken, chatId) {
   }
 
   for (const chunk of chunks) {
-    const res = await fetch(
+    const res = await postJSON(
       `https://api.telegram.org/bot${botToken}/sendMessage`,
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          chat_id: chatId,
-          text: chunk,
-          parse_mode: 'Markdown',
-          disable_web_page_preview: true
-        })
+        chat_id: chatId,
+        text: chunk,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true
       }
     );
 
@@ -100,16 +178,12 @@ async function sendTelegram(text, botToken, chatId) {
       const err = await res.json();
       // If Markdown parsing fails, retry without parse_mode
       if (err.description && err.description.includes("can't parse")) {
-        await fetch(
+        await postJSON(
           `https://api.telegram.org/bot${botToken}/sendMessage`,
           {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              chat_id: chatId,
-              text: chunk,
-              disable_web_page_preview: true
-            })
+            chat_id: chatId,
+            text: chunk,
+            disable_web_page_preview: true
           }
         );
       } else {
@@ -127,21 +201,20 @@ async function sendTelegram(text, botToken, chatId) {
 // Sends the digest via Resend's email API.
 // The user provides their own Resend API key and email address.
 async function sendEmail(text, apiKey, toEmail) {
-  const res = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`
-    },
-    body: JSON.stringify({
+  const res = await postJSON(
+    'https://api.resend.com/emails',
+    {
       from: 'AI Builders Digest <digest@resend.dev>',
       to: [toEmail],
       subject: `AI Builders Digest — ${new Date().toLocaleDateString('en-US', {
         weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
       })}`,
       text: text
-    })
-  });
+    },
+    {
+      Authorization: `Bearer ${apiKey}`
+    }
+  );
 
   if (!res.ok) {
     const err = await res.json();
@@ -153,7 +226,7 @@ async function sendEmail(text, apiKey, toEmail) {
 
 async function main() {
   // Load env and config
-  loadEnv({ path: ENV_PATH });
+  await loadEnvFile(ENV_PATH);
 
   let config = {};
   if (existsSync(CONFIG_PATH)) {

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -6,55 +6,7 @@
   "packages": {
     "": {
       "name": "follow-builders-scripts",
-      "version": "1.0.0",
-      "dependencies": {
-        "dotenv": "^16.4.0",
-        "proper-lockfile": "^4.1.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+      "version": "1.0.0"
     }
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,9 +6,5 @@
   "scripts": {
     "generate-feed": "node generate-feed.js",
     "prepare-digest": "node prepare-digest.js"
-  },
-  "dependencies": {
-    "dotenv": "^16.4.0",
-    "proper-lockfile": "^4.1.0"
   }
 }

--- a/scripts/prepare-digest.js
+++ b/scripts/prepare-digest.js
@@ -16,10 +16,12 @@
 // Output: JSON to stdout
 // ============================================================================
 
-import { readFile, mkdir } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 // -- Constants ---------------------------------------------------------------
 
@@ -38,19 +40,39 @@ const PROMPT_FILES = [
   'digest-intro.md',
   'translate.md'
 ];
+const execFileAsync = promisify(execFile);
 
 // -- Fetch helpers -----------------------------------------------------------
 
-async function fetchJSON(url) {
-  const res = await fetch(url);
-  if (!res.ok) return null;
-  return res.json();
+async function fetchText(url) {
+  // Some agent environments rely on HTTP(S)_PROXY. Node's built-in fetch does
+  // not consistently honor those proxy variables, while curl usually does.
+  try {
+    const { stdout } = await execFileAsync(
+      'curl',
+      ['-fsSL', '--max-time', '30', url],
+      { maxBuffer: 50 * 1024 * 1024 }
+    );
+    return stdout;
+  } catch {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(30000) });
+      if (!res.ok) return null;
+      return res.text();
+    } catch {
+      return null;
+    }
+  }
 }
 
-async function fetchText(url) {
-  const res = await fetch(url);
-  if (!res.ok) return null;
-  return res.text();
+async function fetchJSON(url) {
+  const text = await fetchText(url);
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
 }
 
 // -- Main --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add Codex to the supported agent docs and installation examples.
- Replace Claude-specific skill directory references with a generic SKILL_DIR fallback for script commands.
- Make feed fetching and Telegram/email delivery work better in proxy-based agent environments by falling back through curl/fetch.
- Remove unused script package dependencies so the digest path can run without npm install.

## Validation
- node --check scripts/prepare-digest.js
- node --check scripts/deliver.js
- printf 'delivery smoke test' | node scripts/deliver.js
- node scripts/prepare-digest.js > /tmp/fb-pr-prepared.json
