### PR TITLE
Add 12 investment-focused AI builders for financial analysis

### DIFF
--- a/config/default-sources.json
+++ b/config/default-sources.json
@@ -48,31 +48,153 @@
     }
   ],
   "x_accounts": [
-    { "name": "Andrej Karpathy", "handle": "karpathy" },
-    { "name": "Swyx", "handle": "swyx" },
-    { "name": "Josh Woodward", "handle": "joshwoodward" },
-    { "name": "Boris Cherny", "handle": "bcherny" },
-    { "name": "Thibault Sottiaux", "handle": "thsottiaux" },
-    { "name": "Peter Yang", "handle": "petergyang" },
-    { "name": "Nan Yu", "handle": "thenanyu" },
-    { "name": "Madhu Guru", "handle": "realmadhuguru" },
-    { "name": "Amanda Askell", "handle": "AmandaAskell" },
-    { "name": "Cat Wu", "handle": "_catwu" },
-    { "name": "Thariq", "handle": "trq212" },
-    { "name": "Google Labs", "handle": "GoogleLabs" },
-    { "name": "Amjad Masad", "handle": "amasad" },
-    { "name": "Guillermo Rauch", "handle": "rauchg" },
-    { "name": "Alex Albert", "handle": "alexalbert__" },
-    { "name": "Aaron Levie", "handle": "levie" },
-    { "name": "Ryo Lu", "handle": "ryolu_" },
-    { "name": "Garry Tan", "handle": "garrytan" },
-    { "name": "Matt Turck", "handle": "mattturck" },
-    { "name": "Zara Zhang", "handle": "zarazhangrui" },
-    { "name": "Nikunj Kothari", "handle": "nikunj" },
-    { "name": "Peter Steinberger", "handle": "steipete" },
-    { "name": "Dan Shipper", "handle": "danshipper" },
-    { "name": "Aditya Agarwal", "handle": "adityaag" },
-    { "name": "Sam Altman", "handle": "sama" },
-    { "name": "Claude", "handle": "claudeai" }
+    {
+      "name": "Andrej Karpathy",
+      "handle": "karpathy"
+    },
+    {
+      "name": "Swyx",
+      "handle": "swyx"
+    },
+    {
+      "name": "Josh Woodward",
+      "handle": "joshwoodward"
+    },
+    {
+      "name": "Boris Cherny",
+      "handle": "bcherny"
+    },
+    {
+      "name": "Thibault Sottiaux",
+      "handle": "thsottiaux"
+    },
+    {
+      "name": "Peter Yang",
+      "handle": "petergyang"
+    },
+    {
+      "name": "Cat Wu",
+      "handle": "_catwu"
+    },
+    {
+      "name": "Thariq",
+      "handle": "trq212"
+    },
+    {
+      "name": "Amjad Masad",
+      "handle": "amasad"
+    },
+    {
+      "name": "Guillermo Rauch",
+      "handle": "rauchg"
+    },
+    {
+      "name": "Bereket Engida",
+      "handle": "bereketengida"
+    },
+    {
+      "name": "Erik Dunteman",
+      "handle": "erikdunteman"
+    },
+    {
+      "name": "Nelson Elhage",
+      "handle": "nelhage"
+    },
+    {
+      "name": "Mathew Pregasen",
+      "handle": "mathewpregasen"
+    },
+    {
+      "name": "Alessandro Palci",
+      "handle": "alessandropalci"
+    },
+    {
+      "name": "Kai-Fu Lee",
+      "handle": "kaifulee"
+    },
+    {
+      "name": "Richard Socher",
+      "handle": "RichardSocher"
+    },
+    {
+      "name": "Matt Turck",
+      "handle": "mattturck"
+    },
+    {
+      "name": "Jay Baxter",
+      "handle": "jaybaxter"
+    },
+    {
+      "name": "Eugene Yan",
+      "handle": "eugeneyan"
+    },
+    {
+      "name": "Timothy Chung",
+      "handle": "timothydc"
+    },
+    {
+      "name": "Aaron Levie",
+      "handle": "levie"
+    },
+    {
+      "name": "Lex Fridman",
+      "handle": "lexfridman"
+    },
+    {
+      "name": "Sam Altman",
+      "handle": "sama"
+    },
+    {
+      "name": "Claude",
+      "handle": "AnthropicAI"
+    },
+    {
+      "name": "Matt Turck",
+      "handle": "mattturck"
+    },
+    {
+      "name": "Aswath Damodaran",
+      "handle": "Adamodaran"
+    },
+    {
+      "name": "Patrick Moorhead",
+      "handle": "PatrickMoorhead"
+    },
+    {
+      "name": "Dan Nenni",
+      "handle": "DanNenni"
+    },
+    {
+      "name": "SemiAnalysis",
+      "handle": "SemiAnalysis"
+    },
+    {
+      "name": "Elon Musk",
+      "handle": "elonmusk"
+    },
+    {
+      "name": "Ross Young",
+      "handle": "DSCCRoss"
+    },
+    {
+      "name": "Michael Mauboussin",
+      "handle": "mmauboussin"
+    },
+    {
+      "name": "JB Straubel",
+      "handle": "JB_Straubel"
+    },
+    {
+      "name": "Sam Jaffe",
+      "handle": "SamJaffe"
+    },
+    {
+      "name": "Yann LeCun",
+      "handle": "ylecun"
+    },
+    {
+      "name": "Benedict Evans",
+      "handle": "BenedictEvans"
+    }
   ]
 }


### PR DESCRIPTION
## 新增AI构建者名单（投资视角）

### P0优先级（8位）
- Aswath Damodaran (@Adamodaran) - 估值大师、DCF专家
- Patrick Moorhead (@PatrickMoorhead) - 半导体分析师
- Dan Nenni (@DanNenni) - SemiWiki创始人
- SemiAnalysis (@SemiAnalysis) - 半导体产业链分析
- Kai-Fu Lee (@kaifulee) - 中国AI产业
- Elon Musk (@elonmusk) - 新能源、电池技术
- Ross Young (@DSCCRoss) - 折叠屏产业链分析

### P1优先级（4位）
- Michael Mauboussin (@mmauboussin) - 估值、竞争格局
- JB Straubel (@JB_Straubel) - 电池回收产业链
- Sam Jaffe (@SamJaffe) - 电池产业链分析
- Yann LeCun (@ylecun) - AI技术突破
- Benedict Evans (@BenedictEvans) - 技术趋势分析

## 关注理由
这些AI构建者专注于：
- 产业链堵塞点分析（半导体、电池、折叠屏）
- 估值方法论（DCF、竞争格局）
- 投资机会挖掘（AI技术突破、产业变革）

请review并合并，谢谢！