### PR TITLE
ci: bump checkout/setup-node to v5 before the June 16 Node 20 deprecation

### DIFF
--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -24,11 +24,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: cd scripts && npm install


### PR DESCRIPTION
## Why

The daily **Generate Feeds** job currently uses `actions/checkout@v4` and `actions/setup-node@v4`, which run on the Node 20 action runtime. Every recent run logs:

> ##[warning]Node.js 20 actions are deprecated… Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

So this is a time-boxed breakage, not a hypothetical — the scheduled job risks failing right after **2026-06-16**.

## Change

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5` (these run on the Node 24 runtime)
- `node-version: '20'` → `'22'` for the feed script (20 is past active LTS)

No workflow logic or feed-generation behavior changes.

## Note for maintainer (not part of this PR)

While here I traced the "thin podcast / empty blog" feel some users notice — it's **working as designed**, not a bug:
- `fetchPodcastContent` returns exactly one episode per run (the newest unseen one that pod2txt can transcribe), so it drains a backlog 1/day.
- Blogs report "0 new" when the 3 newest posts are already in `state.seenArticles`; `MAX_INDEX_SCAN` is also pinned to `MAX_ARTICLES_PER_BLOG = 3`, so if more than 3 posts land between runs the overflow never gets scanned. Happy to send a follow-up decoupling scan-depth from the output cap if that's of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)