### PR TITLE
Add configurable womenswear industry mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 # Follow Builders, Not Influencers
 
+This skill now supports two content modes:
+
+- `ai-builders` (default): central AI builders feeds for X/Twitter, podcasts, and blogs.
+- `womenswear`: a local industry content pool that turns collected social/article
+  source material into short-video topic ideas.
+
 An AI-powered digest that tracks the top builders in AI — researchers, founders, PMs,
 and engineers who are actually building things — and delivers curated summaries of
 what they're saying.
@@ -66,6 +72,46 @@ Edit the files in the `prompts/` folder:
 These are plain English instructions, not code. Changes take effect on the next digest.
 
 ## Default Sources
+
+## Industry Mode: Womenswear
+
+Set `industry` to `womenswear` and `outputMode` to `short_video_topics` in
+`~/.follow-builders/config.json` to use the local womenswear workflow:
+
+```json
+{
+  "language": "zh",
+  "industry": "womenswear",
+  "outputMode": "short_video_topics",
+  "delivery": { "method": "stdout" },
+  "onboardingComplete": true
+}
+```
+
+Add collected source material to
+`~/.follow-builders/industries/womenswear/feed.json`:
+
+```json
+{
+  "items": [
+    {
+      "sourceType": "social",
+      "platform": "xiaohongshu",
+      "sourceName": "Account or publication",
+      "author": "Author name",
+      "title": "Post or article title",
+      "url": "https://example.com/original-source",
+      "publishedAt": "2026-06-18T00:00:00.000Z",
+      "text": "Collected source text, excerpt, transcript, or notes.",
+      "tags": ["trend", "styling"]
+    }
+  ]
+}
+```
+
+AI builders sources are still centrally maintained. Industry sources are local
+and user-managed. The first womenswear version does not automatically scrape
+Xiaohongshu, Douyin, WeChat, or similar platforms.
 
 ### Podcasts (6)
 - [Latent Space](https://www.youtube.com/@LatentSpacePod)

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,13 @@ description: AI builders digest — monitors top AI builders on X and YouTube po
 
 # Follow Builders, Not Influencers
 
+This skill supports two content modes:
+
+- `ai-builders` (default): fetches the centrally maintained AI builders feeds.
+- `womenswear`: reads local industry content from
+  `~/.follow-builders/industries/womenswear/feed.json` and turns it into
+  short-video topic ideas.
+
 You are an AI-powered content curator that tracks the top builders in AI — the people
 actually building products, running companies, and doing research — and delivers
 digestible summaries of what they're saying.
@@ -334,6 +341,21 @@ internet connection. Otherwise, use whatever content is in the JSON.
 
 ### Step 3: Check for content
 
+If `config.industry` is `womenswear`, use the industry workflow instead of the
+AI builders tweet/podcast/blog workflow:
+
+- Read `items`, `industry`, `stats`, and `prompts.short_video_topics` from the JSON.
+- If `status` is `empty`, tell the user to add source items to
+  `~/.follow-builders/industries/womenswear/feed.json`.
+- If `status` is `error`, show the `message` and stop.
+- Turn the feed items into short-video topic ideas following
+  `prompts.short_video_topics`.
+- Every factual observation or topic must cite at least one `url` from `items`.
+- Items without `url` can only be used as style/context reference, not evidence.
+- Do not invent trends, quotes, sales results, or market data.
+- Include risk notes for absolute claims, exaggerated sales promises, unsupported
+  competitor comparisons, or claims without source links.
+
 If `stats.podcastEpisodes` is 0 AND `stats.xBuilders` is 0, tell the user:
 "No new updates from your builders today. Check back tomorrow!" Then stop.
 
@@ -414,10 +436,31 @@ Just output the digest directly.
 When the user says something that sounds like a settings change, handle it:
 
 ### Source Changes
-The source list is managed centrally and cannot be modified by users.
-If a user asks to add or remove sources, tell them: "The source list is curated
-centrally and updates automatically. If you'd like to suggest a source, you can
-open an issue at https://github.com/zarazhangrui/follow-builders."
+AI builders sources are managed centrally and update automatically. If a user
+wants to suggest an AI builders source, direct them to
+https://github.com/zarazhangrui/follow-builders.
+
+Industry mode sources are local and user-managed. For `womenswear`, tell users
+to add collected items to `~/.follow-builders/industries/womenswear/feed.json`
+using this shape:
+
+```json
+{
+  "items": [
+    {
+      "sourceType": "social",
+      "platform": "xiaohongshu",
+      "sourceName": "Account or publication",
+      "author": "Author name",
+      "title": "Post or article title",
+      "url": "https://example.com/original-source",
+      "publishedAt": "2026-06-18T00:00:00.000Z",
+      "text": "Collected source text, excerpt, transcript, or notes.",
+      "tags": ["trend", "styling"]
+    }
+  ]
+}
+```
 
 ### Schedule Changes
 - "Switch to weekly/daily" → Update `frequency` in config.json

--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -14,6 +14,18 @@
       "default": "en",
       "description": "Digest language: en (English), zh (Chinese), bilingual (both)"
     },
+    "industry": {
+      "type": "string",
+      "enum": ["ai-builders", "womenswear"],
+      "default": "ai-builders",
+      "description": "Content domain. ai-builders uses the central feed; womenswear uses a local industry feed."
+    },
+    "outputMode": {
+      "type": "string",
+      "enum": ["digest", "short_video_topics"],
+      "default": "digest",
+      "description": "Output format. Use short_video_topics for industry content intended for short-video ideation."
+    },
     "timezone": {
       "type": "string",
       "default": "America/Los_Angeles",

--- a/config/industries/womenswear/profile.json
+++ b/config/industries/womenswear/profile.json
@@ -1,0 +1,25 @@
+{
+  "id": "womenswear",
+  "name": "Womenswear",
+  "description": "A practical industry feed for womenswear retail, sourcing, styling, ecommerce, and short-video topic development.",
+  "audience": [
+    "womenswear store owners",
+    "womenswear ecommerce sellers",
+    "buyers and merchandisers",
+    "fashion content creators",
+    "consumers who want to avoid poor clothing purchases"
+  ],
+  "outputMode": "short_video_topics",
+  "contentGoals": [
+    "spot useful womenswear market observations",
+    "turn source material into shootable short-video topics",
+    "surface hooks, angles, and practical talking points",
+    "preserve source links for every factual claim"
+  ],
+  "contentBoundaries": [
+    "Do not promise guaranteed sales, viral reach, or profit.",
+    "Avoid absolute claims such as must-buy, guaranteed hit, or risk-free.",
+    "Do not criticize named competitors without source-backed evidence.",
+    "Treat unlinked material as style reference only, not factual evidence."
+  ]
+}

--- a/config/industries/womenswear/sources.template.json
+++ b/config/industries/womenswear/sources.template.json
@@ -1,0 +1,49 @@
+{
+  "industry": "womenswear",
+  "notes": "Fill this template with the sources you want to track. The first version does not scrape these platforms automatically; add collected content to ~/.follow-builders/industries/womenswear/feed.json.",
+  "sources": [
+    {
+      "sourceType": "social",
+      "platform": "xiaohongshu",
+      "sourceName": "",
+      "author": "",
+      "url": "",
+      "tags": ["trend", "styling", "retail"]
+    },
+    {
+      "sourceType": "social",
+      "platform": "douyin",
+      "sourceName": "",
+      "author": "",
+      "url": "",
+      "tags": ["short-video", "sales", "styling"]
+    },
+    {
+      "sourceType": "article",
+      "platform": "wechat",
+      "sourceName": "",
+      "author": "",
+      "url": "",
+      "tags": ["industry", "retail", "sourcing"]
+    },
+    {
+      "sourceType": "article",
+      "platform": "website",
+      "sourceName": "",
+      "author": "",
+      "url": "",
+      "tags": ["trend", "market"]
+    }
+  ],
+  "feedItemShape": {
+    "sourceType": "social | article",
+    "platform": "xiaohongshu | douyin | weibo | wechat | website | other",
+    "sourceName": "Account, publication, or site name",
+    "author": "Author or account owner",
+    "title": "Post or article title",
+    "url": "Original source URL",
+    "publishedAt": "ISO date string when known",
+    "text": "Collected text, excerpt, transcript, or notes",
+    "tags": ["trend", "sourcing", "styling"]
+  }
+}

--- a/prompts/industries/womenswear/short-video-topics.md
+++ b/prompts/industries/womenswear/short-video-topics.md
@@ -1,0 +1,45 @@
+# Womenswear Short-Video Topic Prompt
+
+You are turning womenswear industry source material into practical short-video topics.
+
+## Inputs
+
+You receive:
+- `industry`: the industry profile and content boundaries
+- `items`: local feed entries collected by the user
+- `config.language`: `en`, `zh`, or `bilingual`
+
+Each item may include `sourceType`, `platform`, `sourceName`, `author`, `title`, `url`,
+`publishedAt`, `text`, and `tags`.
+
+## Output
+
+Create a compact digest with three sections:
+
+1. `Today's Womenswear Observations`
+   - 2-4 concise observations from the source material.
+   - Each observation must cite at least one source URL.
+
+2. `Shootable Short-Video Topics`
+   - Produce 3-7 topics, depending on how much source material exists.
+   - For each topic include:
+     - `Title`: a shootable short-video title.
+     - `Core point`: the specific insight or argument.
+     - `Opening hook`: the first sentence or scene.
+     - `Best format`: talking head, try-on comparison, shop-floor scene, product close-up, interview, or screenshot walkthrough.
+     - `Source`: one or more original URLs from the feed items.
+
+3. `Risk Notes`
+   - List any wording risks: absolute claims, exaggerated sales promises, unsupported competitor comparisons, or claims without source links.
+
+## Rules
+
+- Every factual topic must trace back to at least one `url` from `items`.
+- If an item has no URL, use it only as style/context reference and say it was not used as evidence.
+- Do not invent market data, brand performance, trends, or quotes.
+- Do not promise that a product will sell, go viral, or make money.
+- Prefer practical womenswear angles: selection, fabric, fit, styling, inventory risk, pricing perception, customer objections, ecommerce conversion, and store-floor selling.
+- If there is not enough content, say what is missing instead of padding.
+- If `config.language` is `zh`, write the whole digest in Chinese.
+- If `config.language` is `en`, write the whole digest in English.
+- If `config.language` is `bilingual`, put Chinese directly after each English paragraph.

--- a/prompts/industries/womenswear/translate.md
+++ b/prompts/industries/womenswear/translate.md
@@ -1,0 +1,9 @@
+# Womenswear Translation Prompt
+
+When translating womenswear short-video ideas into Chinese:
+
+- Keep the language direct, practical, and natural for short-video creators.
+- Preserve source URLs exactly.
+- Translate professional terms clearly: fit, silhouette, fabric, texture, inventory, conversion, and customer objection.
+- Avoid exaggerated words such as guaranteed, must explode, certain profit, or risk-free.
+- Keep titles punchy but not misleading.

--- a/scripts/prepare-digest.js
+++ b/scripts/prepare-digest.js
@@ -16,7 +16,7 @@
 // Output: JSON to stdout
 // ============================================================================
 
-import { readFile, mkdir } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -25,6 +25,7 @@ import { homedir } from 'os';
 
 const USER_DIR = join(homedir(), '.follow-builders');
 const CONFIG_PATH = join(USER_DIR, 'config.json');
+const SUPPORTED_INDUSTRIES = new Set(['womenswear']);
 
 const FEED_X_URL = 'https://raw.githubusercontent.com/zarazhangrui/follow-builders/main/feed-x.json';
 const FEED_PODCASTS_URL = 'https://raw.githubusercontent.com/zarazhangrui/follow-builders/main/feed-podcasts.json';
@@ -36,6 +37,11 @@ const PROMPT_FILES = [
   'summarize-tweets.md',
   'summarize-blogs.md',
   'digest-intro.md',
+  'translate.md'
+];
+
+const INDUSTRY_PROMPT_FILES = [
+  'short-video-topics.md',
   'translate.md'
 ];
 
@@ -53,23 +59,178 @@ async function fetchText(url) {
   return res.text();
 }
 
+async function readJSON(path) {
+  return JSON.parse((await readFile(path, 'utf-8')).replace(/^\uFEFF/, ''));
+}
+
+async function loadPromptFile({ filename, localDir, userDir, errors }) {
+  const userPath = join(userDir, filename);
+  const localPath = join(localDir, filename);
+
+  if (existsSync(userPath)) {
+    return readFile(userPath, 'utf-8');
+  }
+
+  if (existsSync(localPath)) {
+    return readFile(localPath, 'utf-8');
+  }
+
+  errors.push(`Could not load prompt: ${filename}`);
+  return '';
+}
+
+function normalizeIndustry(industry) {
+  if (!industry || industry === 'ai-builders') return 'ai-builders';
+  return industry;
+}
+
+async function prepareIndustryDigest({ config, scriptDir, errors }) {
+  const industry = normalizeIndustry(config.industry);
+
+  if (!SUPPORTED_INDUSTRIES.has(industry)) {
+    return {
+      status: 'error',
+      message: `Unsupported industry: ${industry}`,
+      supportedIndustries: [...SUPPORTED_INDUSTRIES]
+    };
+  }
+
+  const localIndustryDir = join(scriptDir, '..', 'config', 'industries', industry);
+  const localPromptsDir = join(scriptDir, '..', 'prompts', 'industries', industry);
+  const userIndustryDir = join(USER_DIR, 'industries', industry);
+  const userPromptsDir = join(userIndustryDir, 'prompts');
+  const feedPath = join(userIndustryDir, 'feed.json');
+  const profilePath = join(localIndustryDir, 'profile.json');
+
+  let profile = {};
+  if (existsSync(profilePath)) {
+    try {
+      profile = await readJSON(profilePath);
+    } catch (err) {
+      errors.push(`Could not read industry profile: ${err.message}`);
+    }
+  } else {
+    errors.push(`Could not find industry profile: ${industry}`);
+  }
+
+  const prompts = {};
+  for (const filename of INDUSTRY_PROMPT_FILES) {
+    const key = filename.replace('.md', '').replace(/-/g, '_');
+    prompts[key] = await loadPromptFile({
+      filename,
+      localDir: localPromptsDir,
+      userDir: userPromptsDir,
+      errors
+    });
+  }
+
+  let items = [];
+  if (!existsSync(feedPath)) {
+    return {
+      status: 'empty',
+      message: `No local content feed found for industry "${industry}". Add items to ${feedPath}.`,
+      generatedAt: new Date().toISOString(),
+      config: {
+        language: config.language || 'en',
+        frequency: config.frequency || 'daily',
+        delivery: config.delivery || { method: 'stdout' },
+        industry,
+        outputMode: config.outputMode || 'short_video_topics'
+      },
+      industry: profile,
+      items,
+      prompts,
+      stats: { items: 0, linkedItems: 0, sourceTypes: {} },
+      errors: errors.length > 0 ? errors : undefined
+    };
+  }
+
+  try {
+    const feed = await readJSON(feedPath);
+    items = Array.isArray(feed) ? feed : feed.items || [];
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `Could not parse local content feed for industry "${industry}": ${err.message}`,
+      feedPath
+    };
+  }
+
+  const sourceTypes = {};
+  for (const item of items) {
+    const type = item.sourceType || 'unknown';
+    sourceTypes[type] = (sourceTypes[type] || 0) + 1;
+  }
+
+  if (items.length === 0) {
+    return {
+      status: 'empty',
+      message: `No local content items found for industry "${industry}". Add items to ${feedPath}.`,
+      generatedAt: new Date().toISOString(),
+      config: {
+        language: config.language || 'en',
+        frequency: config.frequency || 'daily',
+        delivery: config.delivery || { method: 'stdout' },
+        industry,
+        outputMode: config.outputMode || 'short_video_topics'
+      },
+      industry: profile,
+      items,
+      prompts,
+      stats: { items: 0, linkedItems: 0, sourceTypes },
+      errors: errors.length > 0 ? errors : undefined
+    };
+  }
+
+  return {
+    status: 'ok',
+    generatedAt: new Date().toISOString(),
+    config: {
+      language: config.language || 'en',
+      frequency: config.frequency || 'daily',
+      delivery: config.delivery || { method: 'stdout' },
+      industry,
+      outputMode: config.outputMode || 'short_video_topics'
+    },
+    industry: profile,
+    items,
+    stats: {
+      items: items.length,
+      linkedItems: items.filter((item) => Boolean(item.url)).length,
+      sourceTypes
+    },
+    prompts,
+    errors: errors.length > 0 ? errors : undefined
+  };
+}
+
 // -- Main --------------------------------------------------------------------
 
 async function main() {
   const errors = [];
+  const scriptDir = decodeURIComponent(new URL('.', import.meta.url).pathname);
 
   // 1. Read user config
   let config = {
     language: 'en',
     frequency: 'daily',
-    delivery: { method: 'stdout' }
+    delivery: { method: 'stdout' },
+    industry: 'ai-builders',
+    outputMode: 'digest'
   };
   if (existsSync(CONFIG_PATH)) {
     try {
-      config = JSON.parse(await readFile(CONFIG_PATH, 'utf-8'));
+      config = await readJSON(CONFIG_PATH);
     } catch (err) {
       errors.push(`Could not read config: ${err.message}`);
     }
+  }
+
+  const industry = normalizeIndustry(config.industry);
+  if (industry !== 'ai-builders') {
+    const output = await prepareIndustryDigest({ config, scriptDir, errors });
+    console.log(JSON.stringify(output, null, 2));
+    return;
   }
 
   // 2. Fetch all three feeds
@@ -105,7 +266,6 @@ async function main() {
   // Otherwise, fetch the latest from GitHub so they get central improvements.
   // If GitHub is unreachable, fall back to the local copy shipped with the skill.
   const prompts = {};
-  const scriptDir = decodeURIComponent(new URL('.', import.meta.url).pathname);
   const localPromptsDir = join(scriptDir, '..', 'prompts');
   const userPromptsDir = join(USER_DIR, 'prompts');
 
@@ -144,7 +304,9 @@ async function main() {
     config: {
       language: config.language || 'en',
       frequency: config.frequency || 'daily',
-      delivery: config.delivery || { method: 'stdout' }
+      delivery: config.delivery || { method: 'stdout' },
+      industry: 'ai-builders',
+      outputMode: config.outputMode || 'digest'
     },
 
     // Content to remix


### PR DESCRIPTION
## Summary
- Add configurable industry mode while preserving the default AI builders feed flow
- Add womenswear profile, local source template, and short-video topic prompts
- Teach prepare-digest.js to read local womenswear feed items from ~/.follow-builders/industries/womenswear/feed.json
- Document the local industry feed shape in README and SKILL.md

## Verification
- node --check scripts/prepare-digest.js
- prepare-digest default AI builders path returns status=ok with x/podcasts/blogs
- prepare-digest womenswear path returns status=ok with items and short_video_topics prompt