### PR TITLE
stop digest from repeating the same podcast item verbatim

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -356,10 +356,14 @@ Read the prompts from the `prompts` field in the JSON:
 **Podcast (process second):** The `podcasts` array has at most 1 episode. If present:
 1. Summarize its `transcript` using `prompts.summarize_podcast`
 2. Use `name`, `title`, and `url` from the JSON object — NOT from the transcript
+3. Write ONE summary block for that one episode. Do NOT repeat it, and do NOT split a
+   single episode's transcript into multiple entries — one conversation is one episode.
 
 Assemble the digest following `prompts.digest_intro`.
 
 **ABSOLUTE RULES:**
+- NEVER repeat an item. Each tweet, blog post, and podcast episode appears exactly once.
+  No restating the same summary under a second heading.
 - NEVER invent or fabricate content. Only use what's in the JSON.
 - Every piece of content MUST have its URL. No URL = do not include.
 - Do NOT guess job titles. Use the `bio` field or just the person's name.

--- a/prompts/digest-intro.md
+++ b/prompts/digest-intro.md
@@ -12,13 +12,24 @@ Then organize content in this order:
 
 1. X / TWITTER section — list each builder with new posts
 2. OFFICIAL BLOGS section — list each blog post from AI company blogs (OpenAI, Anthropic, etc.)
-3. PODCASTS section — list each podcast with new episodes
+3. PODCASTS section — list each podcast episode present in the feed
 
 ## Rules
 
 - Only include sources that have new content
 - Skip any source with nothing new
 - Under each source, paste the individual summary you generated
+
+### No duplication (critical)
+- Each item in the feed appears EXACTLY ONCE in the digest. One tweet/builder = one
+  block. One blog post = one block. One podcast episode = one block.
+- NEVER repeat the same summary, paragraph, or "Key insights" list two or three times.
+- The PODCASTS section usually has only ONE episode in the feed. Write a single summary
+  for it and move on. Do NOT pad the section by restating the same episode under a new
+  heading, and do NOT split one episode's transcript into multiple "episode" entries —
+  a single conversation is one episode, however many topics it covers.
+- Before finishing, scan your draft: if any block says essentially the same thing as an
+  earlier block, delete the duplicate.
 
 ### Podcast links
 - After each podcast summary, include the specific video URL from the JSON `url` field

--- a/prompts/summarize-podcast.md
+++ b/prompts/summarize-podcast.md
@@ -5,6 +5,9 @@ the key insights without watching the full episode.
 
 ## Instructions
 
+- Produce EXACTLY ONE remix for this episode. One episode = one summary block. Never
+  write the summary more than once, and never split a single conversation into multiple
+  entries — even a long, multi-topic live interview is one episode.
 - Write a remix of 200-400 words
 - Start with a one-sentence "The Takeaway" — what's the single most important takeaway?
 - Introduce the context and the speaker's information (name, role/company, background) and why the audience should care


### PR DESCRIPTION
The podcast section often repeated one episode's summary 2-3 times with
identical wording. The data was never duplicated (feed is capped at one
episode); the model was padding the section because the prompts framed
podcasts as an open-ended plural list and nothing forbade duplication.

- digest-intro.md: add a "No duplication (critical)" rule; clarify the
  podcast section is usually one episode and a multi-topic conversation
  is still one episode; add a final dedup scan.
- summarize-podcast.md: require exactly one remix per episode.
- SKILL.md: add a no-repeat absolute rule and a one-block podcast note.