### PR TITLE
Add official AI lab X accounts to the watchlist

### DIFF
--- a/config/default-sources.json
+++ b/config/default-sources.json
@@ -73,6 +73,13 @@
     { "name": "Dan Shipper", "handle": "danshipper" },
     { "name": "Aditya Agarwal", "handle": "adityaag" },
     { "name": "Sam Altman", "handle": "sama" },
-    { "name": "Claude", "handle": "claudeai" }
+    { "name": "Claude", "handle": "claudeai" },
+    { "name": "Anthropic", "handle": "AnthropicAI" },
+    { "name": "OpenAI", "handle": "OpenAI" },
+    { "name": "Google DeepMind", "handle": "GoogleDeepMind" },
+    { "name": "AI at Meta", "handle": "AIatMeta" },
+    { "name": "Mistral AI", "handle": "MistralAI" },
+    { "name": "Hugging Face", "handle": "huggingface" },
+    { "name": "xAI", "handle": "xai" }
   ]
 }


### PR DESCRIPTION
## What

Adds the primary official AI lab / company X accounts to `config/default-sources.json`:

- Anthropic (`@AnthropicAI`)
- OpenAI (`@OpenAI`)
- Google DeepMind (`@GoogleDeepMind`)
- AI at Meta (`@AIatMeta`)
- Mistral AI (`@MistralAI`)
- Hugging Face (`@huggingface`)
- xAI (`@xai`)

## Why

The watchlist skews heavily toward individual builders and already tracks `@claudeai` and `@GoogleLabs`, but not the labs' main official accounts. Downstream digests that lead with "new features, launches, and official company announcements" therefore have to infer launches from individuals reposting them, rather than reading the first-party source directly. These seven accounts are where the launches are actually announced.

## Notes

- Config-only, no code changes. The accounts flow through the existing X feed path.
- Official lab *blogs* (Meta AI, Mistral) are a natural follow-up but each needs a bespoke index/content parser in `scripts/generate-feed.js`, and OpenAI / Google DeepMind blog indexes are JS-rendered (no static article links server-side), so they would need an RSS-based fetcher. Left out of this PR to keep it low-risk.
