### PR TITLE
fix(blog): re-check lookback window after resolving publish date

### DIFF
--- a/scripts/generate-feed.js
+++ b/scripts/generate-feed.js
@@ -969,6 +969,16 @@ async function fetchBlogContent(blogs, state, errors) {
             continue;
           }
 
+          // Step 3.5: Re-check the lookback window once the real publish
+          // date is known. The index listed this article with publishedAt:
+          // null, so the Step-2 cutoff test passed. If the date resolved
+          // from the article page is outside the window, mark it seen so
+          // it isn't refetched every run and skip it (fail-open otherwise).
+          const resolvedPub = extracted.publishedAt || article.publishedAt || null;
+          if (resolvedPub && new Date(resolvedPub) < cutoff) {
+            state.seenArticles[article.url] = Date.now();
+            continue;
+          }
           // Merge extracted data with what we already have from the index
           results.push({
             source: "blog",


### PR DESCRIPTION
## Problem

feed-blogs.json declares `lookbackHours: 72` but shipped an article dated Jun 08, 2026 — roughly 60 days outside the window. Downstream consumers trust that declaration and present the item as current.

## Root cause

`parseClaudeBlogIndex` hardcodes `publishedAt: null`, so the Step-2 filter `if (article.publishedAt && new Date(article.publishedAt) < cutoff)` short-circuits and never rejects anything. The real date is only resolved later, from JSON-LD in `extractClaudeBlogArticleContent`, and is written straight into the output without being re-validated. The same failure mode affects `parseAnthropicEngineeringIndex` whenever it falls back to regex parsing.

The existing fallback heuristic — "articles without dates are accepted if they appear near the top of the listing" — doesn't hold on claude.com/blog, a Webflow page where the link regex scans raw HTML in DOM order rather than publish order. Combined with `MAX_INDEX_SCAN = 3`, a pinned older post can also crowd out genuinely new ones.

## Fix

Re-apply the same cutoff once the real date is known, just before `results.push`. Unparseable dates still pass through (fail-open, unchanged behaviour). Skipped articles are marked seen so they aren't refetched every run.

---

我在 2026-08-08 的 feed 里复现到了这条：https://claude.com/blog/claude-for-foundation-models，它实际上是2026-06-08