### PR TITLE
fix digest reliability and source freshness

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -325,17 +325,26 @@ The script outputs a single JSON blob with everything you need:
 - `config` — user's language and delivery preferences
 - `podcasts` — podcast episodes with full transcripts
 - `x` — builders with their recent tweets (text, URLs, bios)
+- `blogs` — official blog posts with article content and original URLs
 - `prompts` — the remix instructions to follow
 - `stats` — counts of episodes and tweets
-- `errors` — non-fatal issues (IGNORE these)
+- `sourceStatus` — per-source fetch health, age, and stale status
+- `errors` — non-fatal issues; inspect them and report relevant source failures briefly
 
 If the script fails entirely (no JSON output), tell the user to check their
 internet connection. Otherwise, use whatever content is in the JSON.
 
 ### Step 3: Check for content
 
-If `stats.podcastEpisodes` is 0 AND `stats.xBuilders` is 0, tell the user:
-"No new updates from your builders today. Check back tomorrow!" Then stop.
+Check `sourceStatus` and `errors` before interpreting zero counts. A failed source is
+not evidence of "no updates"; report the retrieval problem and summarize any sources
+that did succeed. Treat `sourceStatus.<source>.stale: true` as unavailable for today's
+digest; do not summarize stale content as a new update. Only say "No new updates" when
+all relevant sources were fetched successfully, none are stale, and
+`stats.podcastEpisodes`, `stats.xBuilders`, and `stats.blogPosts` are all 0.
+
+Every included item must have its original URL from the JSON. For podcasts, only use a
+direct episode/video URL; a YouTube channel or playlist page is not an episode source.
 
 ### Step 4: Remix content
 
@@ -346,6 +355,7 @@ Read the prompts from the `prompts` field in the JSON:
 - `prompts.digest_intro` — overall framing rules
 - `prompts.summarize_podcast` — how to remix podcast transcripts
 - `prompts.summarize_tweets` — how to remix tweets
+- `prompts.summarize_blogs` — how to remix official blog posts
 - `prompts.translate` — how to translate to Chinese
 
 **Tweets (process first):** The `x` array has builders with tweets. Process one at a time:
@@ -353,7 +363,12 @@ Read the prompts from the `prompts` field in the JSON:
 2. Summarize their `tweets` using `prompts.summarize_tweets`
 3. Every tweet MUST include its `url` from the JSON
 
-**Podcast (process second):** The `podcasts` array has at most 1 episode. If present:
+**Blogs (process second):** The `blogs` array has official posts. Process one at a time:
+1. Summarize its `content` using `prompts.summarize_blogs`
+2. Use `source`, `title`, `author`, `publishedAt`, and `url` from the JSON object
+3. Every blog item MUST include its `url` from the JSON
+
+**Podcast (process third):** The `podcasts` array has at most 1 episode. If present:
 1. Summarize its `transcript` using `prompts.summarize_podcast`
 2. Use `name`, `title`, and `url` from the JSON object — NOT from the transcript
 

--- a/scripts/generate-feed.js
+++ b/scripts/generate-feed.js
@@ -15,7 +15,16 @@
 
 import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import {
+  ensurePodcastState,
+  prunePodcastFailures,
+  recordPodcastFailure,
+  recordPodcastSuccess,
+  shouldSkipPodcastAfterFailures,
+} from "./podcast-state.js";
+import { isUsableSourceUrl } from "./source-url.js";
 
 // -- Constants ---------------------------------------------------------------
 
@@ -35,7 +44,7 @@ const X_RETRY_STATUSES = new Set([500, 502, 503, 504]);
 const X_RETRY_ATTEMPTS = 3;
 
 // State file lives in the repo root so it gets committed by GitHub Actions
-const SCRIPT_DIR = decodeURIComponent(new URL(".", import.meta.url).pathname);
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const STATE_PATH = join(SCRIPT_DIR, "..", "state-feed.json");
 
 // -- State Management --------------------------------------------------------
@@ -45,15 +54,26 @@ const STATE_PATH = join(SCRIPT_DIR, "..", "state-feed.json");
 
 async function loadState() {
   if (!existsSync(STATE_PATH)) {
-    return { seenTweets: {}, seenVideos: {}, seenArticles: {} };
+    return {
+      seenTweets: {},
+      seenVideos: {},
+      failedVideos: {},
+      seenArticles: {},
+    };
   }
   try {
     const state = JSON.parse(await readFile(STATE_PATH, "utf-8"));
-    // Ensure seenArticles exists for older state files
+    if (!state.seenTweets) state.seenTweets = {};
+    ensurePodcastState(state);
     if (!state.seenArticles) state.seenArticles = {};
     return state;
   } catch {
-    return { seenTweets: {}, seenVideos: {}, seenArticles: {} };
+    return {
+      seenTweets: {},
+      seenVideos: {},
+      failedVideos: {},
+      seenArticles: {},
+    };
   }
 }
 
@@ -66,6 +86,7 @@ async function saveState(state) {
   for (const [id, ts] of Object.entries(state.seenVideos)) {
     if (ts < cutoff) delete state.seenVideos[id];
   }
+  prunePodcastFailures(state, cutoff);
   for (const [id, ts] of Object.entries(state.seenArticles || {})) {
     if (ts < cutoff) delete state.seenArticles[id];
   }
@@ -423,6 +444,12 @@ async function fetchPodcastContent(podcasts, apiKey, state, errors) {
           console.error(`    Skipping "${episode.title}" (already seen)`);
           continue;
         }
+        if (shouldSkipPodcastAfterFailures(state, episode.guid)) {
+          console.error(
+            `    Skipping "${episode.title}" (failure retry limit reached)`,
+          );
+          continue;
+        }
 
         console.error(
           `    Candidate: "${episode.title}" published=${episode.publishedAt || "unknown"}`,
@@ -465,9 +492,6 @@ async function fetchPodcastContent(podcasts, apiKey, state, errors) {
       apiKey,
     );
 
-    // Mark as seen regardless so we don't retry failed episodes daily
-    state.seenVideos[selected.guid] = Date.now();
-
     if (result.error) {
       console.error(
         `    Transcript error: ${result.error} — skipping to next candidate`,
@@ -475,6 +499,7 @@ async function fetchPodcastContent(podcasts, apiKey, state, errors) {
       errors.push(
         `Podcast: Transcript error for "${selected.title}": ${result.error}`,
       );
+      recordPodcastFailure(state, selected.guid, result.error);
       continue;
     }
 
@@ -482,6 +507,7 @@ async function fetchPodcastContent(podcasts, apiKey, state, errors) {
       console.error(
         `    Empty transcript for "${selected.title}" — skipping to next candidate`,
       );
+      recordPodcastFailure(state, selected.guid, "Empty transcript");
       continue;
     }
 
@@ -489,20 +515,30 @@ async function fetchPodcastContent(podcasts, apiKey, state, errors) {
       `    Selected: "${selected.title}" (transcript: ${result.transcript.length} chars)`,
     );
 
-    // Try to resolve the exact YouTube video URL for this episode. If the
-    // lookup fails (no YouTube channel configured, no title match, network
-    // error), fall back to the channel URL so the feed still works.
+    // Prefer the exact YouTube video URL. If lookup fails, use the episode's
+    // own RSS link. Never substitute a channel page for an episode source.
     const youtubeUrl = await findYouTubeEpisodeUrl(
       selected.podcast.url,
       selected.title,
     );
+    const rssEpisodeUrl = isUsableSourceUrl(selected.link)
+      ? selected.link
+      : null;
+    const episodeUrl = youtubeUrl || rssEpisodeUrl;
     if (youtubeUrl) {
       console.error(`    Matched YouTube episode URL: ${youtubeUrl}`);
+    } else if (rssEpisodeUrl) {
+      console.error(`    Using RSS episode URL: ${rssEpisodeUrl}`);
     } else {
       console.error(
-        `    No YouTube episode match found — falling back to channel URL`,
+        `    No direct episode URL found — skipping this candidate`,
       );
+      errors.push(`Podcast: No direct episode URL for "${selected.title}"`);
+      recordPodcastFailure(state, selected.guid, "No direct episode URL");
+      continue;
     }
+
+    recordPodcastSuccess(state, selected.guid);
 
     return [
       {
@@ -510,7 +546,7 @@ async function fetchPodcastContent(podcasts, apiKey, state, errors) {
         name: selected.podcast.name,
         title: selected.title,
         guid: selected.guid,
-        url: youtubeUrl || selected.podcast.url,
+        url: episodeUrl,
         publishedAt: selected.publishedAt,
         transcript: result.transcript,
       },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "generate-feed": "node generate-feed.js",
-    "prepare-digest": "node prepare-digest.js"
+    "prepare-digest": "node prepare-digest.js",
+    "test": "node --test ../tests/prepare-digest.test.mjs ../tests/podcast-state.test.mjs ../tests/skill-contract.test.mjs"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/scripts/podcast-state.js
+++ b/scripts/podcast-state.js
@@ -1,0 +1,38 @@
+export const MAX_PODCAST_FAILURES = 3;
+
+export function ensurePodcastState(state) {
+  if (!state.seenVideos) state.seenVideos = {};
+  if (!state.failedVideos) state.failedVideos = {};
+  return state;
+}
+
+export function shouldSkipPodcastAfterFailures(state, guid) {
+  ensurePodcastState(state);
+  return (state.failedVideos[guid]?.count || 0) >= MAX_PODCAST_FAILURES;
+}
+
+export function recordPodcastFailure(state, guid, reason, nowMs = Date.now()) {
+  ensurePodcastState(state);
+  const previous = state.failedVideos[guid];
+  state.failedVideos[guid] = {
+    count: (previous?.count || 0) + 1,
+    lastAttemptAt: nowMs,
+    lastError: reason || 'unknown error'
+  };
+  return state.failedVideos[guid];
+}
+
+export function recordPodcastSuccess(state, guid, nowMs = Date.now()) {
+  ensurePodcastState(state);
+  state.seenVideos[guid] = nowMs;
+  delete state.failedVideos[guid];
+}
+
+export function prunePodcastFailures(state, cutoffMs) {
+  ensurePodcastState(state);
+  for (const [guid, failure] of Object.entries(state.failedVideos)) {
+    if (!failure?.lastAttemptAt || failure.lastAttemptAt < cutoffMs) {
+      delete state.failedVideos[guid];
+    }
+  }
+}

--- a/scripts/prepare-digest.js
+++ b/scripts/prepare-digest.js
@@ -16,10 +16,14 @@
 // Output: JSON to stdout
 // ============================================================================
 
-import { readFile, mkdir } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+import { filterPodcasts } from './source-url.js';
+
+export { filterPodcasts, isUsableSourceUrl } from './source-url.js';
 
 // -- Constants ---------------------------------------------------------------
 
@@ -39,23 +43,114 @@ const PROMPT_FILES = [
   'translate.md'
 ];
 
+const FEED_FETCH_ATTEMPTS = 3;
+const FEED_FETCH_TIMEOUT_MS = 15000;
+const PROMPT_FETCH_TIMEOUT_MS = 8000;
+const RETRY_DELAY_MS = 500;
+const DEFAULT_MAX_FEED_AGE_HOURS = 30;
+
 // -- Fetch helpers -----------------------------------------------------------
 
-async function fetchJSON(url) {
-  const res = await fetch(url);
-  if (!res.ok) return null;
-  return res.json();
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function describeError(error) {
+  const name = error?.name || 'Error';
+  const message = error?.message || String(error);
+  const causeCode = error?.cause?.code;
+  return causeCode ? `${name}: ${message} (${causeCode})` : `${name}: ${message}`;
+}
+
+function isRetryableStatus(status) {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+export async function fetchJSON(url, label, options = {}) {
+  const fetchImpl = options.fetchImpl || fetch;
+  const attempts = options.attempts || FEED_FETCH_ATTEMPTS;
+  const timeoutMs = options.timeoutMs || FEED_FETCH_TIMEOUT_MS;
+  const retryDelayMs = options.retryDelayMs ?? RETRY_DELAY_MS;
+  const sleepImpl = options.sleepImpl || sleep;
+  let lastError = 'unknown error';
+  let attemptsUsed = 0;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    attemptsUsed = attempt;
+    try {
+      const res = await fetchImpl(url, {
+        headers: { 'User-Agent': 'follow-builders/prepare-digest' },
+        signal: AbortSignal.timeout(timeoutMs)
+      });
+
+      if (res.ok) {
+        try {
+          return { data: await res.json(), attempts: attempt, error: null };
+        } catch (error) {
+          lastError = `invalid JSON (${describeError(error)})`;
+        }
+      } else {
+        lastError = `HTTP ${res.status}`;
+        if (!isRetryableStatus(res.status)) break;
+      }
+    } catch (error) {
+      lastError = describeError(error);
+    }
+
+    if (attempt < attempts) {
+      await sleepImpl(retryDelayMs * attempt);
+    }
+  }
+
+  return {
+    data: null,
+    attempts: attemptsUsed,
+    error: `${label} failed after ${attemptsUsed} attempt(s): ${lastError}`
+  };
 }
 
 async function fetchText(url) {
-  const res = await fetch(url);
-  if (!res.ok) return null;
-  return res.text();
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'follow-builders/prepare-digest' },
+      signal: AbortSignal.timeout(PROMPT_FETCH_TIMEOUT_MS)
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+export function getFeedFreshness(feed, nowMs, maxAgeHours) {
+  if (!feed) {
+    return { generatedAt: null, ageHours: null, stale: false };
+  }
+
+  const generatedAt = feed.generatedAt || null;
+  const generatedAtMs = Date.parse(generatedAt);
+  if (!generatedAt || !Number.isFinite(generatedAtMs)) {
+    return { generatedAt, ageHours: null, stale: true };
+  }
+
+  const ageHours = Math.max(0, (nowMs - generatedAtMs) / (60 * 60 * 1000));
+  return {
+    generatedAt,
+    ageHours: Number(ageHours.toFixed(2)),
+    stale: ageHours > maxAgeHours
+  };
+}
+
+function getMaxFeedAgeHours(config) {
+  const configured = Number(config.maxFeedAgeHours);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_MAX_FEED_AGE_HOURS;
 }
 
 // -- Main --------------------------------------------------------------------
 
-async function main() {
+export async function main() {
   const errors = [];
 
   // 1. Read user config
@@ -73,15 +168,19 @@ async function main() {
   }
 
   // 2. Fetch all three feeds
-  const [feedX, feedPodcasts, feedBlogs] = await Promise.all([
-    fetchJSON(FEED_X_URL),
-    fetchJSON(FEED_PODCASTS_URL),
-    fetchJSON(FEED_BLOGS_URL)
+  const [feedXResult, feedPodcastsResult, feedBlogsResult] = await Promise.all([
+    fetchJSON(FEED_X_URL, 'Tweet feed'),
+    fetchJSON(FEED_PODCASTS_URL, 'Podcast feed'),
+    fetchJSON(FEED_BLOGS_URL, 'Blog feed')
   ]);
 
-  if (!feedX) errors.push('Could not fetch tweet feed');
-  if (!feedPodcasts) errors.push('Could not fetch podcast feed');
-  if (!feedBlogs) errors.push('Could not fetch blog feed');
+  const feedX = feedXResult.data;
+  const feedPodcasts = feedPodcastsResult.data;
+  const feedBlogs = feedBlogsResult.data;
+
+  if (feedXResult.error) errors.push(feedXResult.error);
+  if (feedPodcastsResult.error) errors.push(feedPodcastsResult.error);
+  if (feedBlogsResult.error) errors.push(feedBlogsResult.error);
   if (feedX?.errors?.length) {
     errors.push(
       ...feedX.errors.map((error) => `Tweet feed problem: ${error}`)
@@ -98,6 +197,43 @@ async function main() {
     );
   }
 
+  const maxFeedAgeHours = getMaxFeedAgeHours(config);
+  const feedResults = {
+    x: feedXResult,
+    podcasts: feedPodcastsResult,
+    blogs: feedBlogsResult
+  };
+  const nowMs = Date.now();
+  const sourceStatus = Object.fromEntries(
+    Object.entries(feedResults).map(([name, result]) => {
+      const freshness = getFeedFreshness(result.data, nowMs, maxFeedAgeHours);
+      const staleError = freshness.stale
+        ? `${name} feed is stale: generatedAt=${freshness.generatedAt || 'missing'}, maxAgeHours=${maxFeedAgeHours}`
+        : null;
+      if (staleError) errors.push(staleError);
+      return [name, {
+        ok: Boolean(result.data),
+        attempts: result.attempts,
+        generatedAt: freshness.generatedAt,
+        ageHours: freshness.ageHours,
+        stale: freshness.stale,
+        error: result.error || staleError
+      }];
+    })
+  );
+
+  const freshFeedX = sourceStatus.x.ok && !sourceStatus.x.stale ? feedX : null;
+  const freshFeedPodcasts = sourceStatus.podcasts.ok && !sourceStatus.podcasts.stale
+    ? feedPodcasts
+    : null;
+  const freshFeedBlogs = sourceStatus.blogs.ok && !sourceStatus.blogs.stale
+    ? feedBlogs
+    : null;
+  const podcasts = filterPodcasts(freshFeedPodcasts?.podcasts || [], errors);
+  const unhealthyFeedCount = Object.values(sourceStatus).filter(
+    source => !source.ok || source.stale
+  ).length;
+
   // 3. Load prompts with priority: user custom > remote (GitHub) > local default
   //
   // If the user has a custom prompt at ~/.follow-builders/prompts/<file>,
@@ -105,7 +241,7 @@ async function main() {
   // Otherwise, fetch the latest from GitHub so they get central improvements.
   // If GitHub is unreachable, fall back to the local copy shipped with the skill.
   const prompts = {};
-  const scriptDir = decodeURIComponent(new URL('.', import.meta.url).pathname);
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
   const localPromptsDir = join(scriptDir, '..', 'prompts');
   const userPromptsDir = join(USER_DIR, 'prompts');
 
@@ -137,29 +273,35 @@ async function main() {
 
   // 4. Build the output — everything the LLM needs in one blob
   const output = {
-    status: 'ok',
+    status: unhealthyFeedCount === 0 ? 'ok' : 'partial',
     generatedAt: new Date().toISOString(),
 
     // User preferences
     config: {
       language: config.language || 'en',
+      timezone: config.timezone || 'UTC',
       frequency: config.frequency || 'daily',
+      maxFeedAgeHours,
       delivery: config.delivery || { method: 'stdout' }
     },
 
     // Content to remix
-    podcasts: feedPodcasts?.podcasts || [],
-    x: feedX?.x || [],
-    blogs: feedBlogs?.blogs || [],
+    podcasts,
+    x: freshFeedX?.x || [],
+    blogs: freshFeedBlogs?.blogs || [],
 
     // Stats for the LLM to reference
     stats: {
-      podcastEpisodes: feedPodcasts?.podcasts?.length || 0,
-      xBuilders: feedX?.x?.length || 0,
-      totalTweets: (feedX?.x || []).reduce((sum, a) => sum + a.tweets.length, 0),
-      blogPosts: feedBlogs?.blogs?.length || 0,
+      podcastEpisodes: podcasts.length,
+      xBuilders: freshFeedX?.x?.length || 0,
+      totalTweets: (freshFeedX?.x || []).reduce((sum, a) => sum + a.tweets.length, 0),
+      blogPosts: freshFeedBlogs?.blogs?.length || 0,
       feedGeneratedAt: feedX?.generatedAt || feedPodcasts?.generatedAt || feedBlogs?.generatedAt || null
     },
+
+    // Per-source fetch health. Empty content is only a true "no updates" result
+    // when the corresponding source reports ok=true.
+    sourceStatus,
 
     // Prompts — the LLM reads these and follows the instructions
     prompts,
@@ -171,10 +313,13 @@ async function main() {
   console.log(JSON.stringify(output, null, 2));
 }
 
-main().catch(err => {
-  console.error(JSON.stringify({
-    status: 'error',
-    message: err.message
-  }));
-  process.exit(1);
-});
+const entryPath = process.argv[1] ? resolve(process.argv[1]) : null;
+if (entryPath === fileURLToPath(import.meta.url)) {
+  main().catch(err => {
+    console.error(JSON.stringify({
+      status: 'error',
+      message: err.message
+    }));
+    process.exit(1);
+  });
+}

--- a/scripts/source-url.js
+++ b/scripts/source-url.js
@@ -1,0 +1,28 @@
+export function isUsableSourceUrl(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+
+    const host = url.hostname.toLowerCase().replace(/^www\./, '');
+    if (host === 'youtu.be') return url.pathname.length > 1;
+    if (host === 'youtube.com' || host === 'm.youtube.com') {
+      if (url.pathname === '/watch') return Boolean(url.searchParams.get('v'));
+      return /^\/(live|shorts)\/[^/]+/.test(url.pathname);
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function filterPodcasts(podcasts, errors) {
+  return podcasts.filter(episode => {
+    if (isUsableSourceUrl(episode?.url)) return true;
+
+    errors.push(
+      `Podcast skipped because it has no direct episode URL: ${episode?.title || episode?.name || 'unknown episode'}`
+    );
+    return false;
+  });
+}

--- a/tests/podcast-state.test.mjs
+++ b/tests/podcast-state.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MAX_PODCAST_FAILURES,
+  prunePodcastFailures,
+  recordPodcastFailure,
+  recordPodcastSuccess,
+  shouldSkipPodcastAfterFailures,
+} from '../scripts/podcast-state.js';
+
+test('podcast failures remain retryable until the bounded limit', () => {
+  const state = { seenVideos: {}, failedVideos: {} };
+  const guid = 'episode-1';
+
+  for (let count = 1; count < MAX_PODCAST_FAILURES; count++) {
+    const failure = recordPodcastFailure(state, guid, `failure ${count}`, count);
+    assert.equal(failure.count, count);
+    assert.equal(shouldSkipPodcastAfterFailures(state, guid), false);
+  }
+
+  recordPodcastFailure(state, guid, 'final failure', MAX_PODCAST_FAILURES);
+  assert.equal(shouldSkipPodcastAfterFailures(state, guid), true);
+  assert.equal(state.seenVideos[guid], undefined);
+});
+
+test('podcast success marks seen and clears prior failures', () => {
+  const state = { seenVideos: {}, failedVideos: {} };
+  recordPodcastFailure(state, 'episode-2', 'temporary failure', 100);
+  recordPodcastSuccess(state, 'episode-2', 200);
+
+  assert.equal(state.seenVideos['episode-2'], 200);
+  assert.equal(state.failedVideos['episode-2'], undefined);
+});
+
+test('old podcast failures are pruned for a future retry window', () => {
+  const state = {
+    seenVideos: {},
+    failedVideos: {
+      old: { count: 3, lastAttemptAt: 10, lastError: 'old' },
+      current: { count: 1, lastAttemptAt: 30, lastError: 'current' },
+    },
+  };
+
+  prunePodcastFailures(state, 20);
+  assert.equal(state.failedVideos.old, undefined);
+  assert.equal(state.failedVideos.current.count, 1);
+});

--- a/tests/prepare-digest.test.mjs
+++ b/tests/prepare-digest.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchJSON,
+  filterPodcasts,
+  getFeedFreshness,
+} from '../scripts/prepare-digest.js';
+
+test('fetchJSON retries a transient connection failure', async () => {
+  let calls = 0;
+  const result = await fetchJSON('https://example.test/feed.json', 'Test feed', {
+    attempts: 3,
+    retryDelayMs: 0,
+    sleepImpl: async () => {},
+    fetchImpl: async () => {
+      calls++;
+      if (calls === 1) {
+        const error = new Error('fetch failed');
+        error.cause = { code: 'UND_ERR_CONNECT_TIMEOUT' };
+        throw error;
+      }
+      return {
+        ok: true,
+        json: async () => ({ generatedAt: '2026-08-15T06:00:00.000Z' }),
+      };
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.attempts, 2);
+  assert.equal(result.error, null);
+  assert.equal(result.data.generatedAt, '2026-08-15T06:00:00.000Z');
+});
+
+test('fetchJSON reports a bounded failure after three attempts', async () => {
+  let calls = 0;
+  const result = await fetchJSON('https://example.test/feed.json', 'Test feed', {
+    attempts: 3,
+    retryDelayMs: 0,
+    sleepImpl: async () => {},
+    fetchImpl: async () => {
+      calls++;
+      throw new Error('offline');
+    },
+  });
+
+  assert.equal(calls, 3);
+  assert.equal(result.data, null);
+  assert.equal(result.attempts, 3);
+  assert.match(result.error, /failed after 3 attempt/);
+});
+
+test('feed freshness distinguishes current, stale, and missing timestamps', () => {
+  const now = Date.parse('2026-08-15T15:00:00.000Z');
+  assert.deepEqual(
+    getFeedFreshness({ generatedAt: '2026-08-15T14:00:00.000Z' }, now, 8),
+    { generatedAt: '2026-08-15T14:00:00.000Z', ageHours: 1, stale: false },
+  );
+  assert.equal(
+    getFeedFreshness({ generatedAt: '2026-08-14T14:00:00.000Z' }, now, 8).stale,
+    true,
+  );
+  assert.equal(getFeedFreshness({}, now, 8).stale, true);
+});
+
+test('podcast filtering keeps direct episodes and rejects YouTube containers', () => {
+  const errors = [];
+  const podcasts = [
+    { title: 'Channel', url: 'https://www.youtube.com/@builder/videos' },
+    { title: 'Playlist', url: 'https://www.youtube.com/playlist?list=PL123' },
+    { title: 'Watch', url: 'https://www.youtube.com/watch?v=abc123' },
+    { title: 'Short', url: 'https://youtu.be/abc123' },
+    { title: 'RSS episode', url: 'https://podcast.example/episodes/42' },
+  ];
+
+  const filtered = filterPodcasts(podcasts, errors);
+  assert.deepEqual(filtered.map(item => item.title), ['Watch', 'Short', 'RSS episode']);
+  assert.equal(errors.length, 2);
+});

--- a/tests/skill-contract.test.mjs
+++ b/tests/skill-contract.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const skill = await readFile(new URL('../SKILL.md', import.meta.url), 'utf8');
+const generator = await readFile(
+  new URL('../scripts/generate-feed.js', import.meta.url),
+  'utf8',
+);
+
+test('skill contract includes blogs and stale-feed handling', () => {
+  assert.match(skill, /`blogs` — official blog posts/);
+  assert.match(skill, /prompts\.summarize_blogs/);
+  assert.match(skill, /\*\*Blogs \(process second\):\*\*/);
+  assert.match(skill, /stale: true/);
+});
+
+test('generator records podcast success only after validating an episode URL', () => {
+  const successIndex = generator.indexOf('recordPodcastSuccess(state, selected.guid)');
+  const episodeUrlIndex = generator.indexOf('const episodeUrl = youtubeUrl || rssEpisodeUrl');
+  assert.ok(episodeUrlIndex >= 0);
+  assert.ok(successIndex > episodeUrlIndex);
+  assert.doesNotMatch(generator, /Mark as seen regardless/);
+});


### PR DESCRIPTION
## Summary

- deliver official blog posts through `prepare-digest.js` and expose a dedicated blog summarization prompt
- add bounded feed retries plus per-source freshness metadata, with stale feeds excluded from the digest payload
- reject podcast channel/container URLs and retry transient podcast failures up to three times before suppressing them
- make the Node scripts import-safe on Windows and add focused regression tests for the new behavior

## Root cause

The digest preparation path fetched blog data but did not expose it to the content-delivery workflow. It also had no source-age guard, so an old central feed could be presented as a current update. In the podcast generator, failed episodes could be marked as seen too early, while channel or playlist URLs could pass through as if they were episode sources; both behaviors prevented reliable retry and delivery.

## Impact

Consumers now receive blog items and source-level health information, and stale sources are prevented from appearing as current news. Podcast collection keeps transient failures retryable within a bounded window and only publishes usable episode URLs. The existing digest format remains compatible while gaining explicit freshness and error metadata.

## Validation

- `npm --prefix scripts test` — 9 tests passed
- `node --check scripts/generate-feed.js`
- `node --check scripts/prepare-digest.js`
- Skill structure validation passed with `quick_validate.py`
- live-feed smoke test confirmed current source status and filtered an invalid podcast container URL
