### PR TITLE
fix: remix digest before cron delivery instead of sending raw JSON

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -126,7 +126,7 @@ Ask: "What language do you prefer for your digest?"
 All content is fetched centrally. Skip to Step 6.
 
 **If the user chose Telegram or Email delivery:**
-Create the .env file with only the delivery key they need:
+Create the .env file with the delivery key they need:
 
 ```bash
 mkdir -p ~/.follow-builders
@@ -136,14 +136,21 @@ cat > ~/.follow-builders/.env << 'ENVEOF'
 
 # Resend API key (only if using email delivery)
 # RESEND_API_KEY=paste_your_key_here
+
+# Anthropic API key — required for OpenClaw. Also required on non-persistent
+# platforms (Claude Code, Cursor, etc.) so the cron-triggered remix step
+# (remix-digest.js) has an LLM to call when no agent is attached.
+# ANTHROPIC_API_KEY=paste_your_key_here
 ENVEOF
 ```
 
-Uncomment only the line they need. Open the file for them to paste the key.
+Uncomment the lines they need. Open the file for them to paste the keys.
 
 Tell the user: "All podcast and X/Twitter content is fetched for you automatically
-from a central feed — no API keys needed for that. You only need a key for
-[Telegram/email] delivery."
+from a central feed — no API keys needed for that. You need a key for
+[Telegram/email] delivery, and (if you're on a non-persistent agent like this one)
+an Anthropic API key so your scheduled digest can still be remixed by an LLM when
+no agent is running."
 
 ### Step 6: Show Sources
 
@@ -262,15 +269,28 @@ Common errors and fixes:
 Do NOT proceed to the welcome digest step until the cron delivery has been verified.
 
 **Non-persistent agent + Telegram or Email delivery:**
-Use system crontab so it runs even when the terminal is closed:
+
+Cron runs with no agent attached, so the pipeline needs its own way to do the
+LLM remix step. `remix-digest.js` handles this by calling the Anthropic API
+directly with the same prompts you'd otherwise apply by hand. This requires
+an `ANTHROPIC_API_KEY` in `~/.follow-builders/.env` — ask the user for one if
+they want automated Telegram/Email delivery (get one at
+https://console.anthropic.com/settings/keys). Add it to the .env file the same
+way as the delivery keys in Step 5.
+
+Use system crontab so the pipeline runs even when the terminal is closed:
 ```bash
 SKILL_DIR="<absolute path to the skill directory>"
-(crontab -l 2>/dev/null; echo "<cron expression> cd $SKILL_DIR/scripts && node prepare-digest.js 2>/dev/null | node deliver.js 2>/dev/null") | crontab -
+(crontab -l 2>/dev/null; echo "<cron expression> cd $SKILL_DIR/scripts && node prepare-digest.js 2>/dev/null | node remix-digest.js 2>/dev/null | node deliver.js 2>/dev/null") | crontab -
 ```
-Note: this runs the prepare script and pipes its output directly to delivery,
-bypassing the agent entirely. The digest won't be remixed by an LLM — it will
-deliver the raw JSON. For full remixed digests, the user should use /ai manually
-or switch to OpenClaw.
+
+If `ANTHROPIC_API_KEY` is missing or the API call fails, `remix-digest.js`
+fails closed — it prints nothing to stdout (so `deliver.js` sees an empty
+digest and skips sending) rather than forwarding the raw JSON blob. If the
+user declines to provide a key, tell them: "Without an Anthropic API key,
+I can't remix the digest unattended, so automated delivery would either send
+nothing or raw data. You can still run /ai manually anytime, or switch to
+OpenClaw for automatic delivery without needing this key."
 
 **Non-persistent agent + on-demand only (no Telegram/Email):**
 Skip cron setup entirely. Tell the user: "Since you chose on-demand delivery,

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,11 +1,12 @@
 {
   "name": "follow-builders-scripts",
   "version": "1.0.0",
-  "description": "Scripts for Follow Builders skill — feed generation, digest preparation, delivery",
+  "description": "Scripts for Follow Builders skill — feed generation, digest preparation, remixing, delivery",
   "type": "module",
   "scripts": {
     "generate-feed": "node generate-feed.js",
-    "prepare-digest": "node prepare-digest.js"
+    "prepare-digest": "node prepare-digest.js",
+    "remix-digest": "node remix-digest.js"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "generate-feed": "node generate-feed.js",
     "prepare-digest": "node prepare-digest.js",
-    "remix-digest": "node remix-digest.js"
+    "remix-digest": "node remix-digest.js",
+    "test": "node remix-digest.test.js"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/scripts/remix-digest.js
+++ b/scripts/remix-digest.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+// ============================================================================
+// Follow Builders — Remix Digest (headless LLM step)
+// ============================================================================
+// Bridges the gap between prepare-digest.js and deliver.js when there is no
+// live agent in the loop (e.g. a system crontab entry on a non-persistent
+// platform like Claude Code).
+//
+// Without this script, cron setups piped prepare-digest.js straight into
+// deliver.js:
+//
+//   node prepare-digest.js | node deliver.js
+//
+// That sends the RAW JSON blob (feeds, transcripts, prompts, stats) as the
+// digest body, because there was no LLM in the pipeline to actually remix
+// it per SKILL.md's "Content Delivery" instructions. This script fills that
+// gap by calling the Anthropic API directly with the same prompts an agent
+// would use, so scheduled/cron runs produce a real digest instead of JSON.
+//
+// Usage:
+//   node prepare-digest.js | node remix-digest.js | node deliver.js
+//
+// Requires ANTHROPIC_API_KEY in ~/.follow-builders/.env. If it's missing,
+// this script fails closed: it prints nothing to stdout (so deliver.js sees
+// an empty digest and skips sending) and logs the reason to stderr. Sending
+// nothing is preferable to sending raw JSON.
+// ============================================================================
+
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { config as loadEnv } from 'dotenv';
+
+const USER_DIR = join(homedir(), '.follow-builders');
+const ENV_PATH = join(USER_DIR, '.env');
+
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5';
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const MAX_TOKENS = 8192;
+
+// -- Read prepare-digest.js output from stdin/--file --------------------------
+
+async function getInputJSON() {
+  const args = process.argv.slice(2);
+  const fileIdx = args.indexOf('--file');
+
+  let raw;
+  if (fileIdx !== -1 && args[fileIdx + 1]) {
+    raw = await readFile(args[fileIdx + 1], 'utf-8');
+  } else {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    raw = Buffer.concat(chunks).toString('utf-8');
+  }
+
+  if (!raw || raw.trim().length === 0) {
+    throw new Error('No input received (expected JSON from prepare-digest.js on stdin or --file)');
+  }
+  return JSON.parse(raw);
+}
+
+// -- Build the prompt the LLM needs to remix, following SKILL.md exactly ----
+
+function buildPrompt(data) {
+  const { config, podcasts = [], x = [], blogs = [], prompts = {}, stats = {} } = data;
+  const language = config?.language || 'en';
+
+  const today = new Date().toLocaleDateString('en-US', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
+  });
+
+  return `You are the Follow Builders digest assembler, running unattended via a scheduled job (no human agent is reviewing this before it sends). Follow these instructions exactly — your output will be emailed/messaged as-is.
+
+Today's date: ${today}
+Target language for the final digest: ${language} ("en" = English only, "zh" = Chinese only, "bilingual" = interleave English and Chinese paragraph by paragraph — never all-English-then-all-Chinese)
+
+=== ABSOLUTE RULES ===
+- NEVER invent or fabricate content. Only use what's in the DATA block below.
+- Every piece of content MUST include its source URL from the DATA. No URL = do not include it.
+- Do NOT guess job titles. Use each person's "bio" field, or just their name.
+- Do NOT visit any URL, search the web, or call any API. Everything you need is in DATA.
+- If there is nothing real for a builder/blog/podcast, skip it entirely — do not pad the digest.
+- Output ONLY the final digest text. No preamble, no "Here is the digest", no code fences.
+
+=== ASSEMBLY INSTRUCTIONS (digest-intro) ===
+${prompts.digest_intro || '(no digest-intro prompt provided — use a clean, scannable header + sections for X/Twitter, Blogs, and Podcasts)'}
+
+=== TWEET SUMMARIZATION RULES ===
+${prompts.summarize_tweets || '(no prompt provided — summarize concisely, one paragraph per builder, must include their tweet URLs)'}
+
+=== BLOG SUMMARIZATION RULES ===
+${prompts.summarize_blogs || '(no prompt provided — summarize each post in 1-2 sentences with its link)'}
+
+=== PODCAST SUMMARIZATION RULES ===
+${prompts.summarize_podcast || '(no prompt provided — summarize the transcript in a few sentences, include the episode title and video URL)'}
+
+=== TRANSLATION RULES (only relevant if language is "zh" or "bilingual") ===
+${prompts.translate || '(no prompt provided — translate to natural, fluent simplified Mandarin, keep technical terms and proper nouns in English, keep URLs unchanged)'}
+
+=== DATA (this is the ONLY source of truth — everything to remix is here) ===
+Stats: ${JSON.stringify(stats)}
+
+X / Twitter builders and their tweets:
+${JSON.stringify(x, null, 2)}
+
+Official blog posts:
+${JSON.stringify(blogs, null, 2)}
+
+Podcast episode(s):
+${JSON.stringify(podcasts, null, 2)}
+
+=== YOUR TASK ===
+1. Process tweets first, then blogs, then the podcast (if present), each using their rules above.
+2. Assemble everything following the digest-intro instructions.
+3. Apply the "${language}" language setting exactly as specified.
+4. Output only the finished digest text.`;
+}
+
+// -- Call Anthropic ------------------------------------------------------------
+
+async function remix(apiKey, prompt) {
+  const res = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01'
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: MAX_TOKENS,
+      messages: [{ role: 'user', content: prompt }]
+    })
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Anthropic API error (${res.status}): ${errText}`);
+  }
+
+  const body = await res.json();
+  const text = (body.content || [])
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n')
+    .trim();
+
+  if (!text) throw new Error('Anthropic API returned no text content');
+  return text;
+}
+
+// -- Main ------------------------------------------------------------------
+
+async function main() {
+  loadEnv({ path: ENV_PATH });
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error(JSON.stringify({
+      status: 'error',
+      message: 'ANTHROPIC_API_KEY not set in ~/.follow-builders/.env — cannot remix digest ' +
+        'for unattended/cron delivery. Add a key to enable automated remixing, or run /ai ' +
+        'manually so the live agent can remix it instead. Refusing to forward raw JSON.'
+    }));
+    process.exit(1);
+  }
+
+  let data;
+  try {
+    data = await getInputJSON();
+  } catch (err) {
+    console.error(JSON.stringify({ status: 'error', message: `Bad input: ${err.message}` }));
+    process.exit(1);
+  }
+
+  if (data.status !== 'ok' && !data.podcasts && !data.x) {
+    console.error(JSON.stringify({ status: 'error', message: 'prepare-digest.js reported failure; nothing to remix' }));
+    process.exit(1);
+  }
+
+  const podcastCount = (data.podcasts || []).length;
+  const xCount = (data.x || []).length;
+  const blogCount = (data.blogs || []).length;
+  if (podcastCount === 0 && xCount === 0 && blogCount === 0) {
+    // Nothing new today — say nothing to stdout so deliver.js skips sending.
+    console.error(JSON.stringify({ status: 'skipped', message: 'No new content today' }));
+    return;
+  }
+
+  try {
+    const prompt = buildPrompt(data);
+    const digestText = await remix(apiKey, prompt);
+    console.log(digestText);
+  } catch (err) {
+    console.error(JSON.stringify({ status: 'error', message: err.message }));
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/remix-digest.test.js
+++ b/scripts/remix-digest.test.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+// ============================================================================
+// remix-digest.js — lightweight smoke tests
+// ============================================================================
+// No test framework, no real ANTHROPIC_API_KEY required. Runs remix-digest.js
+// as a child process for each scenario (so its process.exit() calls don't
+// kill this runner) and asserts on stdout/stderr/exit code.
+//
+// Covers the regression this script fixes: cron-based delivery must NEVER
+// forward raw JSON as the digest — it should either produce a real remixed
+// digest, or emit nothing (fail closed) so deliver.js skips sending.
+//
+// Usage: node remix-digest.test.js
+// ============================================================================
+
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = join(__dirname, 'remix-digest.js');
+
+let passed = 0;
+let failed = 0;
+
+function check(name, condition, detail) {
+  if (condition) {
+    console.log(`  ok  - ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL - ${name}${detail ? `: ${detail}` : ''}`);
+    failed++;
+  }
+}
+
+function runScript({ stdin, env }) {
+  return spawnSync('node', [SCRIPT_PATH], {
+    input: stdin,
+    env: { ...process.env, ...env },
+    encoding: 'utf-8'
+  });
+}
+
+// Minimal fixture matching prepare-digest.js's real output shape.
+const FIXTURE_WITH_CONTENT = JSON.stringify({
+  status: 'ok',
+  generatedAt: '2026-08-20T07:00:00.000Z',
+  config: { language: 'en', frequency: 'daily', delivery: { method: 'email', email: 'test@example.com' } },
+  podcasts: [],
+  x: [{
+    handle: 'levie',
+    bio: 'ceo @box',
+    tweets: [{ text: 'AI agents are reshaping software procurement.', url: 'https://x.com/levie/status/999999' }]
+  }],
+  blogs: [],
+  stats: { podcastEpisodes: 0, xBuilders: 1, totalTweets: 1, blogPosts: 0, feedGeneratedAt: '2026-08-20T07:00:00.000Z' },
+  prompts: {
+    digest_intro: 'Start with "AI Builders Digest — [Date]", then list tweets with their URLs.',
+    summarize_tweets: 'Summarize each builder\'s tweets in 1-2 sentences. Always include the tweet URL.',
+    summarize_blogs: 'Summarize each post in 1-2 sentences with its link.',
+    summarize_podcast: 'Summarize the transcript in a few sentences, include title and video URL.',
+    translate: 'Translate to natural, fluent simplified Mandarin.'
+  }
+});
+
+const FIXTURE_NO_CONTENT = JSON.stringify({
+  status: 'ok',
+  config: { language: 'en' },
+  podcasts: [],
+  x: [],
+  blogs: [],
+  stats: { podcastEpisodes: 0, xBuilders: 0, totalTweets: 0, blogPosts: 0 },
+  prompts: {}
+});
+
+// -- Test 1: missing ANTHROPIC_API_KEY must fail closed ----------------------
+console.log('Test: missing ANTHROPIC_API_KEY');
+{
+  const result = runScript({ stdin: FIXTURE_WITH_CONTENT, env: { ANTHROPIC_API_KEY: '' } });
+  check('exits non-zero', result.status !== 0, `got status ${result.status}`);
+  check('stdout is empty (no raw JSON/data forwarded)', result.stdout.trim() === '', `got: ${result.stdout.slice(0, 200)}`);
+  check('stderr explains the reason', /ANTHROPIC_API_KEY/.test(result.stderr));
+}
+
+// -- Test 2: no new content must skip cleanly, not send anything -------------
+console.log('Test: no new content today');
+{
+  const result = runScript({ stdin: FIXTURE_NO_CONTENT, env: { ANTHROPIC_API_KEY: 'irrelevant-since-it-should-skip-before-calling-the-api' } });
+  check('exits zero (soft skip, not an error)', result.status === 0, `got status ${result.status}`);
+  check('stdout is empty (deliver.js will skip sending)', result.stdout.trim() === '', `got: ${result.stdout.slice(0, 200)}`);
+  check('stderr reports skipped', /skipped/i.test(result.stderr));
+}
+
+// -- Test 3: bad/invalid API key against the REAL Anthropic endpoint ---------
+// This intentionally hits the real network to prove the request is well-formed
+// (a 401 from Anthropic's servers, not a local crash) and that failures still
+// fail closed. Skips gracefully if there's no network access in CI.
+console.log('Test: invalid API key against real Anthropic endpoint (network required)');
+{
+  const result = runScript({ stdin: FIXTURE_WITH_CONTENT, env: { ANTHROPIC_API_KEY: 'sk-invalid-test-key-000' } });
+  if (result.status === 0 && result.stdout.trim() === '' && /fetch failed|ENOTFOUND|ECONNREFUSED/i.test(result.stderr + result.stdout)) {
+    console.log('  skip - no network access in this environment');
+  } else {
+    check('exits non-zero', result.status !== 0, `got status ${result.status}`);
+    check('stdout is still empty on failure', result.stdout.trim() === '', `got: ${result.stdout.slice(0, 200)}`);
+    check('stderr surfaces the API error (not a raw crash)', /Anthropic API error/.test(result.stderr), `got: ${result.stderr.slice(0, 300)}`);
+  }
+}
+
+// -- Summary -------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Problem

Non-persistent agents (Claude Code, Cursor, etc.) set up Telegram/Email delivery via a system crontab, per SKILL.md's onboarding instructions:

```
node prepare-digest.js | node deliver.js
```

Cron has no agent attached, so the LLM remix step described in the "Content Delivery" section of SKILL.md never actually runs. Every scheduled send therefore delivers the **raw JSON blob** (full feeds, transcripts, prompts, stats) as the digest body instead of a formatted digest. SKILL.md even acknowledged this in a comment ("this runs the prepare script and pipes its output directly to delivery, bypassing the agent entirely... it will deliver the raw JSON"), but left it as a known limitation rather than fixing it.

I hit this myself — every daily email since at least July has been unrendered JSON instead of a digest.

## Fix

- Add `scripts/remix-digest.js`: reads `prepare-digest.js`'s JSON output and calls the Anthropic Messages API directly with the same prompts (`digest_intro`, `summarize_tweets`, `summarize_blogs`, `summarize_podcast`, `translate`) an agent would otherwise apply by hand, producing a real remixed digest with no agent in the loop.
- Fails **closed**: if `ANTHROPIC_API_KEY` is missing/invalid or the API call errors, it prints nothing to stdout, so `deliver.js` sees an empty digest and skips sending — rather than forwarding raw JSON as before. Also skips cleanly (no email) when there's no new content.
- Update the non-persistent-agent crontab instructions in `SKILL.md` to insert the new step: `prepare-digest.js | remix-digest.js | deliver.js`, and add guidance for requesting an `ANTHROPIC_API_KEY` during onboarding.
- Add a matching `remix-digest` npm script in `scripts/package.json`.
- Add `scripts/remix-digest.test.js`, a dependency-free smoke test (run via `npm test` or `node remix-digest.test.js`) covering the three scenarios that matter most for this fix — see Testing below.

## Testing

Ran against **real, live data** from an actual `prepare-digest.js` run (16 builders, 30 tweets, 1 podcast episode) through the full `prepare-digest.js → remix-digest.js → deliver.js` pipeline:

- `node --check remix-digest.js` — passes.
- **No new content** → exits cleanly, `deliver.js` reports `{"status":"skipped","reason":"Empty digest text"}` (no email sent).
- **Missing `ANTHROPIC_API_KEY`** → prints an actionable error to stderr, nothing to stdout, `deliver.js` again skips sending instead of relaying JSON.
- **Invalid key against the real Anthropic API** (not mocked) → request reached Anthropic's servers and got back a proper `401 authentication_error`, confirming the request (endpoint, headers, JSON body) is well-formed; failed closed the same way as the missing-key case (empty stdout, non-zero exit).
- **Full success path**, verified by stubbing `fetch` to intercept the Anthropic call with a realistic response while feeding it the real 131KB `prepare-digest.js` payload above: confirmed the built prompt correctly embeds the `digest_intro` rules, real tweet URLs, and the configured language setting, and that the parsed digest text flows cleanly through `deliver.js`'s stdout mode (no JSON, no crash).

Added `scripts/remix-digest.test.js` (no test framework, no API key required — runs the script as a child process per scenario) so these regressions are checked automatically going forward:

```
$ npm test
Test: missing ANTHROPIC_API_KEY
  ok  - exits non-zero
  ok  - stdout is empty (no raw JSON/data forwarded)
  ok  - stderr explains the reason
Test: no new content today
  ok  - exits zero (soft skip, not an error)
  ok  - stdout is empty (deliver.js will skip sending)
  ok  - stderr reports skipped
Test: invalid API key against real Anthropic endpoint (network required)
  ok  - exits non-zero
  ok  - stdout is still empty on failure
  ok  - stderr surfaces the API error (not a raw crash)

9 passed, 0 failed
```

I still don't have a live/valid `ANTHROPIC_API_KEY` to run a fully un-mocked success case end-to-end, so please sanity-check the real digest quality from `buildPrompt()` on your side before merging — happy to adjust based on feedback.
