### PR TITLE
feat: add SemiAnalysis, Baillie Gifford Insights blogs and Dylan Patel X source

### DIFF
--- a/config/default-sources.json
+++ b/config/default-sources.json
@@ -52,6 +52,13 @@
       "indexUrl": "https://semianalysis.com/feed/",
       "articleBaseUrl": "https://semianalysis.com/",
       "fetchMethod": "http"
+    },
+    {
+      "name": "Baillie Gifford Insights",
+      "type": "scrape",
+      "indexUrl": "https://www.bailliegifford.com/en/uk/institutional-investor/insights",
+      "articleBaseUrl": "https://www.bailliegifford.com/",
+      "fetchMethod": "http"
     }
   ],
   "x_accounts": [

--- a/config/default-sources.json
+++ b/config/default-sources.json
@@ -45,6 +45,13 @@
       "indexUrl": "https://claude.com/blog",
       "articleBaseUrl": "https://claude.com/blog/",
       "fetchMethod": "http"
+    },
+    {
+      "name": "SemiAnalysis",
+      "type": "scrape",
+      "indexUrl": "https://semianalysis.com/feed/",
+      "articleBaseUrl": "https://semianalysis.com/",
+      "fetchMethod": "http"
     }
   ],
   "x_accounts": [
@@ -73,6 +80,7 @@
     { "name": "Dan Shipper", "handle": "danshipper" },
     { "name": "Aditya Agarwal", "handle": "adityaag" },
     { "name": "Sam Altman", "handle": "sama" },
-    { "name": "Claude", "handle": "claudeai" }
+    { "name": "Claude", "handle": "claudeai" },
+    { "name": "Dylan Patel", "handle": "dylan522p" }
   ]
 }

--- a/scripts/generate-feed.js
+++ b/scripts/generate-feed.js
@@ -1017,6 +1017,130 @@ function extractSemiAnalysisArticleContent(html) {
   return { title, author, publishedAt, content };
 }
 
+// Converts an HTML fragment to readable text, preserving block boundaries
+// (headings, paragraphs and list items become line breaks).
+function htmlToText(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|h[1-6]|li|ul|ol|blockquote|section)>/gi, "\n")
+    .replace(/<(p|div|h[1-6]|li)\b[^>]*>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (m, code) => String.fromCharCode(Number(code)))
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// Parses the Baillie Gifford insights index page (a Next.js app).
+// Article data lives in the __NEXT_DATA__ JSON blob as a large array of
+// insight tiles, each carrying tileHeading / url / publishDate / standfirst.
+function parseBaillieGiffordIndex(html) {
+  const nextDataMatch = html.match(
+    /<script[^>]*id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/i,
+  );
+  if (!nextDataMatch) return [];
+  let data;
+  try {
+    data = JSON.parse(nextDataMatch[1]);
+  } catch {
+    return [];
+  }
+
+  // Recursively find the main insights array: a large list whose items all
+  // carry publishDate and a /insights/ URL. Stop at the first match.
+  const insights = [];
+  (function findInsights(node) {
+    if (insights.length > 0) return;
+    if (Array.isArray(node)) {
+      const matches =
+        node.filter(
+          (item) =>
+            item &&
+            typeof item === "object" &&
+            item.publishDate &&
+            typeof item.url === "string" &&
+            item.url.includes("/insights/"),
+        ).length;
+      if (node.length >= 50 && matches > node.length * 0.9) {
+        for (const item of node) {
+          // Skip external links (Bloomberg, YouTube, etc.) — their pages
+          // cannot be parsed for article content.
+          if (!item.url.includes("bailliegifford.com")) continue;
+          insights.push({
+            title: item.tileHeading || item.title || "",
+            url: item.url,
+            publishedAt: item.publishDate || null,
+            description: item.standfirst || item.tileDescription || "",
+          });
+        }
+        return;
+      }
+      for (const child of node) {
+        if (child && typeof child === "object") findInsights(child);
+        if (insights.length > 0) return;
+      }
+    } else if (node && typeof node === "object") {
+      for (const key of Object.keys(node)) {
+        findInsights(node[key]);
+        if (insights.length > 0) return;
+      }
+    }
+  })(data);
+
+  return insights;
+}
+
+// Extracts the main text content from a Baillie Gifford insight article page.
+// Metadata and body blocks live in the __NEXT_DATA__ JSON: article.publishDate,
+// article.authors, and insightArticleContents[].bodyText (HTML fragments).
+function extractBaillieGiffordArticleContent(html) {
+  const empty = { title: "", author: "", publishedAt: null, content: "" };
+  const nextDataMatch = html.match(
+    /<script[^>]*id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/i,
+  );
+  if (!nextDataMatch) return empty;
+  let data;
+  try {
+    data = JSON.parse(nextDataMatch[1]);
+  } catch {
+    return empty;
+  }
+
+  const article = data?.props?.pageProps?.article || {};
+  const title = article.title || article.tileHeading || "";
+  const publishedAt = article.publishDate || null;
+  const authors = Array.isArray(article.authors)
+    ? article.authors.map((a) => a.name).filter(Boolean).join(", ")
+    : "";
+
+  // Concatenate the standfirst and all body blocks, preserving structure
+  const contents = Array.isArray(article.insightArticleContents)
+    ? article.insightArticleContents
+    : [];
+  const parts = [];
+  if (article.standfirst) parts.push(htmlToText(article.standfirst));
+  for (const block of contents) {
+    if (block && typeof block.bodyText === "string" && block.bodyText.trim()) {
+      parts.push(htmlToText(block.bodyText));
+    }
+  }
+
+  return {
+    title,
+    author: authors,
+    publishedAt,
+    content: parts.filter(Boolean).join("\n\n"),
+  };
+}
+
 // Main blog fetching orchestrator.
 // For each blog source in the config, discovers new articles, deduplicates
 // against previously seen URLs, fetches full article content, and returns
@@ -1049,6 +1173,8 @@ async function fetchBlogContent(blogs, state, errors) {
         candidates = parseClaudeBlogIndex(indexHtml);
       } else if (blog.indexUrl.includes("semianalysis.com")) {
         candidates = parseSemiAnalysisIndex(indexHtml);
+      } else if (blog.indexUrl.includes("bailliegifford.com")) {
+        candidates = parseBaillieGiffordIndex(indexHtml);
       }
 
       // Step 2: Filter to unseen articles, cap at MAX_ARTICLES_PER_BLOG.
@@ -1100,6 +1226,8 @@ async function fetchBlogContent(blogs, state, errors) {
             extracted = extractClaudeBlogArticleContent(articleHtml);
           } else if (article.url.includes("semianalysis.com")) {
             extracted = extractSemiAnalysisArticleContent(articleHtml);
+          } else if (article.url.includes("bailliegifford.com")) {
+            extracted = extractBaillieGiffordArticleContent(articleHtml);
           }
 
           if (!extracted || !extracted.content) {

--- a/scripts/generate-feed.js
+++ b/scripts/generate-feed.js
@@ -739,6 +739,53 @@ function parseClaudeBlogIndex(html) {
   return articles;
 }
 
+// Parses the SemiAnalysis blog RSS feed (semianalysis.com/feed/).
+// The feed is standard WordPress RSS 2.0 with <item> entries.
+function parseSemiAnalysisIndex(html) {
+  const articles = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/gi;
+  let itemMatch;
+  while ((itemMatch = itemRegex.exec(html)) !== null) {
+    const item = itemMatch[1];
+    const titleMatch = item.match(/<title>(.*?)<\/title>/is);
+    const linkMatch = item.match(/<link>(.*?)<\/link>/is);
+    const pubDateMatch = item.match(/<pubDate>(.*?)<\/pubDate>/is);
+    const descMatch = item.match(/<description>(.*?)<\/description>/is);
+    if (!linkMatch) continue;
+    articles.push({
+      title: decodeXmlEntities(titleMatch ? titleMatch[1].trim() : ""),
+      url: linkMatch[1].trim(),
+      publishedAt: pubDateMatch
+        ? new Date(pubDateMatch[1].trim()).toISOString()
+        : null,
+      description: decodeXmlEntities(
+        descMatch ? stripCdata(descMatch[1]).trim() : "",
+      ),
+    });
+  }
+  return articles;
+}
+
+// Decodes common XML/HTML entities used in RSS feed fields.
+function decodeXmlEntities(str) {
+  return str
+    .replace(/&#x([0-9a-fA-F]+);/g, (m, hex) =>
+      String.fromCharCode(parseInt(hex, 16)),
+    )
+    .replace(/&#(\d+);/g, (m, code) => String.fromCharCode(Number(code)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+// Strips CDATA wrappers from RSS description fields.
+function stripCdata(str) {
+  return str.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1");
+}
+
 // Extracts the main text content from an Anthropic Engineering article page.
 // Tries the embedded JSON first (Next.js SSR data), then falls back to
 // stripping HTML tags from the article body.
@@ -883,6 +930,93 @@ function extractClaudeBlogArticleContent(html) {
   return { title, author, publishedAt, content };
 }
 
+// Extracts the main text content from a SemiAnalysis article page.
+// WordPress layout: <article class="typography newsletter-post post"> wraps the
+// body paragraphs; JSON-LD provides headline/datePublished/author metadata.
+function extractSemiAnalysisArticleContent(html) {
+  let title = "";
+  let author = "";
+  let publishedAt = null;
+  let content = "";
+
+  // Try JSON-LD structured data first (most reliable for metadata)
+  const jsonLdRegex =
+    /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
+  let jsonLdMatch;
+  while ((jsonLdMatch = jsonLdRegex.exec(html)) !== null) {
+    try {
+      const ld = JSON.parse(jsonLdMatch[1]);
+      if (ld["@type"] === "NewsArticle" || ld["@type"] === "Article") {
+        title = ld.headline || ld.name || "";
+        // JSON-LD authors can be an array of {name} objects
+        author = Array.isArray(ld.author)
+          ? ld.author.map((a) => a.name).filter(Boolean).join(", ")
+          : (ld.author?.name || "");
+        publishedAt = ld.datePublished || null;
+        break;
+      }
+    } catch {
+      // Not valid JSON-LD, skip
+    }
+  }
+
+  // Fall back to <time datetime> for the publish date
+  if (!publishedAt) {
+    const timeMatch = html.match(/<time[^>]*datetime="([^"]+)"/i);
+    if (timeMatch) publishedAt = timeMatch[1];
+  }
+
+  // Extract body text from the <article> block, preferring paragraph text
+  const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  const bodyHtml = articleMatch ? articleMatch[1] : html;
+
+  const paragraphRegex = /<p[^>]*>([\s\S]*?)<\/p>/gi;
+  let paragraphMatch;
+  const paragraphs = [];
+  while ((paragraphMatch = paragraphRegex.exec(bodyHtml)) !== null) {
+    // Skip UI chrome paragraphs (share/comment buttons render as <p> blocks)
+    if (/<svg/i.test(paragraphMatch[1]) || /aria-label/i.test(paragraphMatch[1]))
+      continue;
+    const text = paragraphMatch[1]
+      .replace(/^\d+\s*Share\s*/i, "") // drop "N Share" share-count text
+      .replace(/<[^>]+>/g, "")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&nbsp;/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (text) paragraphs.push(text);
+  }
+  content = paragraphs.join("\n\n");
+
+  // Fallback: strip the article body down to plain text
+  if (!content) {
+    content = bodyHtml
+      .replace(/<script[\s\S]*?<\/script>/gi, "")
+      .replace(/<style[\s\S]*?<\/style>/gi, "")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&nbsp;/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  // Title from <h1> if JSON-LD didn't provide one
+  if (!title) {
+    const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+    if (h1Match) title = h1Match[1].replace(/<[^>]+>/g, "").trim();
+  }
+
+  return { title, author, publishedAt, content };
+}
+
 // Main blog fetching orchestrator.
 // For each blog source in the config, discovers new articles, deduplicates
 // against previously seen URLs, fetches full article content, and returns
@@ -913,6 +1047,8 @@ async function fetchBlogContent(blogs, state, errors) {
         candidates = parseAnthropicEngineeringIndex(indexHtml);
       } else if (blog.indexUrl.includes("claude.com")) {
         candidates = parseClaudeBlogIndex(indexHtml);
+      } else if (blog.indexUrl.includes("semianalysis.com")) {
+        candidates = parseSemiAnalysisIndex(indexHtml);
       }
 
       // Step 2: Filter to unseen articles, cap at MAX_ARTICLES_PER_BLOG.
@@ -962,6 +1098,8 @@ async function fetchBlogContent(blogs, state, errors) {
             extracted = extractAnthropicArticleContent(articleHtml);
           } else if (article.url.includes("claude.com/blog")) {
             extracted = extractClaudeBlogArticleContent(articleHtml);
+          } else if (article.url.includes("semianalysis.com")) {
+            extracted = extractSemiAnalysisArticleContent(articleHtml);
           }
 
           if (!extracted || !extracted.content) {


### PR DESCRIPTION
## 变更内容

将 **SemiAnalysis** 与 **Baillie Gifford Insights** 加入追踪范围，并新增 Dylan Patel 的 X 账号。

### 1. SemiAnalysis 博客（semianalysis.com）
- `config/default-sources.json` 的 `blogs` 新增 `SemiAnalysis` 条目，`indexUrl` 指向其 WordPress RSS feed（`https://semianalysis.com/feed/`）
- `scripts/generate-feed.js` 新增（原博客管线硬编码只支持 `anthropic.com` / `claude.com`）：
  - `parseSemiAnalysisIndex()`：解析 RSS 2.0 `<item>` 条目，提取 title / url / pubDate / description（含 XML 实体与 CDATA 清理）
  - `extractSemiAnalysisArticleContent()`：从文章页提取正文，优先 JSON-LD（`NewsArticle`）元数据 + `<article>` 内 `<p>` 段落文本，自动过滤分享按钮等 UI 噪音
  - 在 `fetchBlogContent()` 中接入

### 2. Baillie Gifford Insights（bailliegifford.com）
- `blogs` 新增 `Baillie Gifford Insights` 条目，`indexUrl` 指向 insights 索引页（Next.js 应用，文章数据在 `__NEXT_DATA__` JSON 中，约 1100+ 条，含 `publishDate` 精确日期）
- 新增：
  - `parseBaillieGiffordIndex()`：递归定位 insights 数组（≥50 条且 90% 含 `/insights/` URL），过滤外部链接（Bloomberg / YouTube 等无法提取正文的条目）
  - `extractBaillieGiffordArticleContent()`：从 `__NEXT_DATA__` 读取标题 / 作者 / 发布日期，拼接 standfirst 与正文区块
  - `htmlToText()`：HTML 转纯文本的通用 helper，保留段落与标题结构
  - 在 `fetchBlogContent()` 中接入

### 3. Dylan Patel 的 X 账号
- `x_accounts` 新增 `{ "name": "Dylan Patel", "handle": "dylan522p" }`（SemiAnalysis 创始人）

## 验证
- `node --check scripts/generate-feed.js` 语法通过
- 单元测试：
  - SemiAnalysis：真实 RSS 解析出 10 篇；真实文章页提取完整正文（标题/作者/日期正确，无 UI 噪音）
  - Baillie Gifford：真实索引页解析出 1117 篇站内文章（含精确 `publishDate`）；真实文章页提取 10K+ 字正文，结构清晰
- 集成测试：`node scripts/generate-feed.js --blogs-only` 四个来源均正常处理，无新文章时安静跳过（lookback 窗口外），exit 0

## 备注
- SemiAnalysis 为付费墙站点，feed 与文章页仅能抓取免费可见部分
- 两个来源的最新文章当前均在 72h lookback 窗口外，首次运行会安静跳过，不会灌入历史文章